### PR TITLE
+Optional verbosity control for generic_tracer code

### DIFF
--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -127,6 +127,7 @@ module generic_tracer
   type(g_diag_type), save, pointer :: diag_list => NULL()
 
   logical :: do_generic_tracer = .false.
+  logical :: generic_tracer_register_called = .false.
   logical :: force_update_fluxes = .false.
 
   namelist /generic_tracer_nml/ do_generic_tracer, do_generic_abiotic, do_generic_age, do_generic_argon, do_generic_CFC, &
@@ -136,11 +137,15 @@ module generic_tracer
 contains
 
 
-  subroutine generic_tracer_register
+  subroutine generic_tracer_register(verbosity)
+    integer, optional, intent(in) :: verbosity  !< A 0-9 integer indicating a level of verbosity.
 
     integer :: ioun, io_status, ierr
     integer :: stdoutunit,stdlogunit
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_register'
+
+    ! generic_tracer_register may be called more than once, but it should only be executed once.
+    if (generic_tracer_register_called) return
 
     stdoutunit=stdout();stdlogunit=stdlog()
     ! provide for namelist over-ride of defaults 
@@ -190,7 +195,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_COBALT) &
          call generic_COBALT_register(tracer_list)
     
-    call g_tracer_print_info(tracer_list)
+    call g_tracer_print_info(tracer_list, verbosity)
+
+    generic_tracer_register_called = .true.
 
   end subroutine generic_tracer_register
 

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -372,6 +372,7 @@ module g_tracer_utils
   public :: g_tracer_get_src_info
   public :: g_register_diag_field
   public :: g_send_data
+  public :: fm_string_len
   ! <INTERFACE NAME="g_tracer_add_param">
   !  <OVERVIEW>
   !   Add a new parameter for the generic tracer package
@@ -1028,8 +1029,9 @@ contains
     
   end subroutine g_tracer_init
 
-  subroutine g_tracer_flux_init(g_tracer)
+  subroutine g_tracer_flux_init(g_tracer, verbosity)
     type(g_tracer_type), pointer :: g_tracer
+    integer, optional, intent(in) :: verbosity  !< A 0-9 integer indicating a level of verbosity.
 
 
     !===================================================================
@@ -1048,7 +1050,8 @@ contains
             mol_wt            = g_tracer%flux_gas_molwt,                                      &
             param             = g_tracer%flux_gas_param,                                      &
             ice_restart_file  = g_tracer%ice_restart_file,                                    &
-            ocean_restart_file= g_tracer%flux_gas_restart_file                                &
+            ocean_restart_file= g_tracer%flux_gas_restart_file,                               &
+            verbosity         = verbosity                                                     &
             )
     endif
 
@@ -1057,7 +1060,8 @@ contains
             flux_type            = 'land_sea_runoff',                                         &
             implementation       = 'river',                                                   &
             param                = g_tracer%flux_param,                                       &
-            ice_restart_file     = g_tracer%ice_restart_file                                  &
+            ice_restart_file     = g_tracer%ice_restart_file,                                 &
+            verbosity            = verbosity                                                  &
             )
     endif
 
@@ -1066,7 +1070,8 @@ contains
             flux_type            = 'air_sea_deposition',                                      &
             implementation       = 'wet',                                                     &
             param                = g_tracer%flux_param,                                       &
-            ice_restart_file       = g_tracer%ice_restart_file                                &
+            ice_restart_file     = g_tracer%ice_restart_file,                                 &
+            verbosity            = verbosity                                                  &
             )
     endif
 
@@ -1075,7 +1080,8 @@ contains
             flux_type            = 'air_sea_deposition',                                      &
             implementation       = 'dry',                                                     &
             param                = g_tracer%flux_param,                                       &
-            ice_restart_file     = g_tracer%ice_restart_file                                  &
+            ice_restart_file     = g_tracer%ice_restart_file,                                 &
+            verbosity            = verbosity                                                  &
             )
     endif
     
@@ -3569,20 +3575,28 @@ contains
   end subroutine g_diag_field_add
 
 
-  subroutine g_tracer_print_info(g_tracer_list)
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer 
-    integer               :: num_prog,num_diag
+  subroutine g_tracer_print_info(g_tracer_list, verbosity)
+    type(g_tracer_type),    pointer    :: g_tracer_list ! A pointer to the start of the generic tracer list
+    integer,      optional, intent(in) :: verbosity     ! A 0-9 integer indicating a level of verbosity.
+    type(g_tracer_type),    pointer    :: g_tracer
+    integer :: num_prog, num_diag
+    integer :: verbose
 
     character(len=fm_string_len), parameter :: sub_name = 'g_tracer_print_info'
     character(len=256) :: errorstring
 
     if(.NOT. associated(g_tracer_list)) return
 
-    write(errorstring, '(a)')  ': Dumping generic tracer namelists tree: '
-    call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))    
+    verbose = 5
+    if (present(verbosity)) verbose = verbosity
 
-    if (.not. fm_dump_list('/ocean_mod/namelists', recursive = .true.)) then
-       call mpp_error(FATAL, trim(sub_name) // ': Problem dumping generic tracer namelists tree')
+    if (verbose >= 5) then
+       write(errorstring, '(a)')  ': Dumping generic tracer namelists tree: '
+       call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))    
+
+       if (.not. fm_dump_list('/ocean_mod/namelists', recursive = .true.)) then
+          call mpp_error(FATAL, trim(sub_name) // ': Problem dumping generic tracer namelists tree')
+       endif
     endif
 
     num_prog = 0
@@ -3703,13 +3717,16 @@ contains
 
     if(errorstring .ne. '') then
        !The following cannot be FATAL for backward compatibility with MOM5 and GOLD
-       call mpp_error(WARNING, trim(sub_name) // ' : there are tracers with required source properties that are not set in the field_table. Grep the stdout for NOTEs from g_tracer_print_info and correct the field_table!'  )
+       call mpp_error(WARNING, trim(sub_name) // ' : there are tracers with required source properties that are not set '//&
+                      'in the field_table. Grep the stdout for NOTEs from g_tracer_print_info and correct the field_table!')
     endif
 
-    write(errorstring, '(a,i4)')  ': Number of prognostic generic tracers = ',num_prog
-    call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))    
-    write(errorstring, '(a,i4)')  ': Number of diagnostic generic tracers = ',num_diag
-    call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))     
+    if (verbose >= 3) then
+       write(errorstring, '(a,i4)')  ': Number of prognostic generic tracers = ',num_prog
+       call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))    
+       write(errorstring, '(a,i4)')  ': Number of diagnostic generic tracers = ',num_diag
+       call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))     
+    endif
 
   end subroutine g_tracer_print_info
 


### PR DESCRIPTION
  This commit includes three distinct changes to the generic_tracer code to
regulate output verbosity, increase robustness, and make available for a module
use a variable size that is required to use the generic_tracer_utilities.
Specifically these changes are:

1. Added optional verbosity arguments to g_tracer_print_info, g_tracer_flux_init
   and generic_tracer_register, to allow for the run-time specification of the
   volume of diagnostic output.  Some are directly implemented in the generic
   tracer code, while others pass through to an existing optional argument in
   aof_set_coupler_flux.

2. Added a generic_tracer_register_called module variable to generic_tracer.F90.
   Because of the way generic_tracer_register is structured and allocates data,
   there will be problems if it is executed more than once.  This new module
   variable allows it to be called multiple times without the damaging effects
   of executing it more than once.  This regulation is more appropriate to occur
   in the generic_tracer module, because the coding conventions for this module
   make extensive use of module data, whereas MOM6 does not do this.

3. Make the variable fm_string_len publicly available from the g_tracer_utils
   module.  Several routines in g_tracer_utils specify that this is the required
   length of their character array arguments, so this variable should be shared
   from this module, rather than requiring calling modules to reference another
   infrastructure module.