### PR TITLE
Updates for boundary layer residence time tracer and flexible gas params

### DIFF
--- a/generic_tracers/generic_BLING.F90
+++ b/generic_tracers/generic_BLING.F90
@@ -177,6 +177,8 @@ module generic_BLING
   use time_manager_mod,  only: time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
   use constants_mod,     only: WTMCO2, WTMO2
+  use fms_mod,           only: stdout, stdlog,mpp_pe,mpp_root_pe
+  use data_override_mod, only: data_override
 
   use g_tracer_utils, only : g_diag_type,g_tracer_type
   use g_tracer_utils, only : g_tracer_start_param_list,g_tracer_end_param_list
@@ -186,7 +188,7 @@ module generic_BLING
   use g_tracer_utils, only : g_tracer_coupler_set,g_tracer_coupler_get
   use g_tracer_utils, only : g_tracer_send_diag, g_tracer_get_values  
   use g_tracer_utils, only : register_diag_field=>g_register_diag_field
-  use g_tracer_utils, only : g_send_data
+  use g_tracer_utils, only : g_send_data, is_root_pe
 
   use FMS_ocmip2_co2calc_mod, only : FMS_ocmip2_co2calc, CO2_dope_vector
 
@@ -207,10 +209,12 @@ module generic_BLING
   public generic_BLING_update_from_bottom
   public generic_BLING_set_boundary_values
   public generic_BLING_end
+  public as_param_bling
 
-  !The following logical for using this module is overwritten 
-  ! generic_tracer_nml namelist
+  !The following variables for using this module 
+  ! are overwritten by generic_tracer_nml namelist
   logical, save :: do_generic_BLING = .false.
+  character(len=10), save :: as_param_bling = 'gfdl_cmip6'
 
   real, parameter :: sperd = 24.0 * 3600.0
   real, parameter :: spery = 365.25 * sperd
@@ -309,7 +313,8 @@ namelist /generic_bling_nml/ co2_calc, do_14c, do_carbon, do_carbon_pre, &
 
      real    :: htotal_scale_lo, htotal_scale_hi, htotal_in
      real    :: Rho_0, a_0, a_1, a_2, a_3, a_4, a_5, b_0, b_1, b_2, b_3, c_0
-     real    :: a1_co2, a2_co2, a3_co2, a4_co2, a1_o2, a2_o2, a3_o2, a4_o2
+     real    :: a1_co2, a2_co2, a3_co2, a4_co2, a5_co2 
+     real    :: a1_o2, a2_o2, a3_o2,  a4_o2,  a5_o2
 
 !
 ! The prefixes "f_" refers to a "field" and "j" to a volumetric rate, and 
@@ -1857,29 +1862,50 @@ write (stdlogunit, generic_bling_nml)
     call g_tracer_add_param('b_2', bling%b_2, -1.03410e-02 )
     call g_tracer_add_param('b_3', bling%b_3, -8.17083e-03)
     call g_tracer_add_param('c_0', bling%c_0, -4.88682e-07)
+    !
     !-----------------------------------------------------------------------
-    !     Schmidt number coefficients
+    !      Schmidt number coefficients
     !-----------------------------------------------------------------------
-    !  Compute the Schmidt number of CO2 in seawater using the 
-    !  formulation presented by Wanninkhof (1992, J. Geophys. Res., 97,
-    !  7373-7382).
-    !-----------------------------------------------------------------------
-    !New Wanninkhof numbers
-    call g_tracer_add_param('a1_co2', bling%a1_co2,  2068.9)
-    call g_tracer_add_param('a2_co2', bling%a2_co2, -118.63)
-    call g_tracer_add_param('a3_co2', bling%a3_co2,  2.9311)
-    call g_tracer_add_param('a4_co2', bling%a4_co2, -0.027)
+    if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+        !  Compute the Schmidt number of CO2 in seawater using the 
+        !  formulation presented by Wanninkhof (1992, J. Geophys. Res., 97,
+        !  7373-7382).
+        call g_tracer_add_param('a1_co2', bling%a1_co2,  2068.9)
+        call g_tracer_add_param('a2_co2', bling%a2_co2, -118.63)
+        call g_tracer_add_param('a3_co2', bling%a3_co2,  2.9311)
+        call g_tracer_add_param('a4_co2', bling%a4_co2, -0.027)
+        call g_tracer_add_param('a5_co2', bling%a5_co2,  0.0)     ! Not used for W92
+        !  Compute the Schmidt number of O2 in seawater using the 
+        !  formulation proposed by Keeling et al. (1998, Global Biogeochem.
+        !  Cycles, 12, 141-163).
+        call g_tracer_add_param('a1_o2', bling%a1_o2, 1929.7)
+        call g_tracer_add_param('a2_o2', bling%a2_o2, -117.46)
+        call g_tracer_add_param('a3_o2', bling%a3_o2, 3.116)
+        call g_tracer_add_param('a4_o2', bling%a4_o2, -0.0306)
+        call g_tracer_add_param('a5_o2', bling%a5_o2, 0.0)       ! Not used for W92
+        if (is_root_pe()) call mpp_error(NOTE,'generic_bling: Using Schmidt number coefficients for W92')
+    else if (trim(as_param_bling) == 'W14') then
+        !  Compute the Schmidt number of CO2 in seawater using the 
+        !  formulation presented by Wanninkhof 
+        !  (2014, Limnol. Oceanogr., 12, 351-362)
+        call g_tracer_add_param('a1_co2', bling%a1_co2,    2116.8)
+        call g_tracer_add_param('a2_co2', bling%a2_co2,   -136.25)
+        call g_tracer_add_param('a3_co2', bling%a3_co2,    4.7353)
+        call g_tracer_add_param('a4_co2', bling%a4_co2, -0.092307)
+        call g_tracer_add_param('a5_co2', bling%a5_co2, 0.0007555)
+        !  Compute the Schmidt number of O2 in seawater using the 
+        !  formulation presented by Wanninkhof 
+        !  (2014, Limnol. Oceanogr., 12, 351-362)
+        call g_tracer_add_param('a1_o2', bling%a1_o2, 1920.4)
+        call g_tracer_add_param('a2_o2', bling%a2_o2, -135.6)
+        call g_tracer_add_param('a3_o2', bling%a3_o2, 5.2122)
+        call g_tracer_add_param('a4_o2', bling%a4_o2, -0.10939)
+        call g_tracer_add_param('a5_o2', bling%a5_o2, 0.00093777)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_bling: Using Schmidt number coefficients for W14')
+    else
+        call mpp_error(FATAL,'generic_BLING: unable to set Schmidt number coefficients for as_param '//trim(as_param_bling))
+    endif
     !---------------------------------------------------------------------
-    !  Compute the Schmidt number of O2 in seawater using the 
-    !  formulation proposed by Keeling et al. (1998, Global Biogeochem.
-    !  Cycles, 12, 141-163).
-    !---------------------------------------------------------------------
-    !New Wanninkhof numbers
-    call g_tracer_add_param('a1_o2', bling%a1_o2, 1929.7)
-    call g_tracer_add_param('a2_o2', bling%a2_o2, -117.46)
-    call g_tracer_add_param('a3_o2', bling%a3_o2, 3.116)
-    call g_tracer_add_param('a4_o2', bling%a4_o2, -0.0306)
-
     call g_tracer_add_param('htotal_scale_lo', bling%htotal_scale_lo, 0.01)
     call g_tracer_add_param('htotal_scale_hi', bling%htotal_scale_hi, 100.0)
 
@@ -2206,7 +2232,17 @@ write (stdlogunit, generic_bling_nml)
   subroutine user_add_tracers(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
     character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+    real :: as_coeff_bling
 
+    if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+      ! Air-sea gas exchange coefficient presented in OCMIP2 protocol.
+      ! Value is 0.337 cm/hr in units of m/s.
+      as_coeff_bling=9.36e-7
+    else
+      ! Value is 0.251 cm/hr in units of m/s
+      as_coeff_bling=6.972e-7
+    endif
+    !-----------------------------------------------------------------------
     !Add here only the parameters that are required at the time of registeration 
     !(to make flux exchanging Ocean tracers known for all PE's) 
     !
@@ -2281,7 +2317,7 @@ write (stdlogunit, generic_bling_nml)
          flux_gas_name  = 'o2_flux',                                &
          flux_gas_type  = 'air_sea_gas_flux_generic',               &
          flux_gas_molwt = WTMO2,                                    &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),               &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /),         &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc' )
 
     !
@@ -2355,21 +2391,21 @@ write (stdlogunit, generic_bling_nml)
       !
       !       DIC (Dissolved inorganic carbon)
       !
-      call g_tracer_add(tracer_list,package_name,    &
-         name       = 'dic',                         &
-         longname   = 'Dissolved Inorganic Carbon',  &
-         units      = 'mol/kg',                      &
-         prog       = .true.,                        &
-         flux_gas       = .true.,                    &
-         flux_gas_name  = 'co2_flux',                &
-         flux_gas_type  = 'air_sea_gas_flux_generic',&
-         flux_gas_molwt = WTMCO2,                    &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),&
+      call g_tracer_add(tracer_list,package_name,                   &
+         name           = 'dic',                                    &
+         longname       = 'Dissolved Inorganic Carbon',             &
+         units          = 'mol/kg',                                 &
+         prog           = .true.,                                   &
+         flux_gas       = .true.,                                   &
+         flux_gas_name  = 'co2_flux',                               &
+         flux_gas_type  = 'air_sea_gas_flux_generic',               &
+         flux_gas_molwt = WTMCO2,                                   &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /),         &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-         flux_runoff    = .true.,                    &
-         flux_param     = (/12.011e-03  /),          &
-         flux_bottom    = .true.,                    &
-         init_value     = 0.001)
+         flux_runoff    = .true.,                                   &
+         flux_param     = (/12.011e-03  /),                         &
+         flux_bottom    = .true.,                                   &
+         init_value     = 0.001                                      )
       !
       !    Cased (CaCO3 concentration in active sediment layer)   
       !
@@ -2393,21 +2429,21 @@ write (stdlogunit, generic_bling_nml)
       !
       !       DIC (Dissolved inorganic carbon)
       !
-      call g_tracer_add(tracer_list,package_name,    &
-         name       = 'dic',                         &
-         longname   = 'Dissolved Inorganic Carbon',  &
-         units      = 'mol/kg',                      &
-         prog       = .true.,                        &
-         flux_gas       = .true.,                    &
-         flux_gas_name  = 'co2_flux',                &
-         flux_gas_type  = 'air_sea_gas_flux_generic',&
-         flux_gas_molwt = WTMCO2,                    &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),&
+      call g_tracer_add(tracer_list,package_name,           &
+         name           = 'dic',                            &
+         longname       = 'Dissolved Inorganic Carbon',     &
+         units          = 'mol/kg',                         &
+         prog           = .true.,                           &
+         flux_gas       = .true.,                           &
+         flux_gas_name  = 'co2_flux',                       &
+         flux_gas_type  = 'air_sea_gas_flux_generic',       &
+         flux_gas_molwt = WTMCO2,                           &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /), &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-         flux_runoff    = .false.,                   &
-         flux_param     = (/12.011e-03  /),          &
-         flux_bottom    = .true.,                    &
-         init_value     = 0.001)
+         flux_runoff    = .false.,                          &
+         flux_param     = (/12.011e-03  /),                 &
+         flux_bottom    = .true.,                           &
+         init_value     = 0.001                              )
       endif                                                    !BURY CACO3>>
     !     
     !Diagnostic Tracers:
@@ -2448,19 +2484,19 @@ write (stdlogunit, generic_bling_nml)
       !   
       !       DIC_sat (Saturation Dissolved inorganic carbon)
       !
-      call g_tracer_add(tracer_list,package_name,    &
-           name       = 'dic_sat',                   &
-           longname   = 'Saturation Dissolved Inorganic Carbon', &
-           units      = 'mol/kg',                    &
-           prog       = .true.,                      &
-           flux_gas       = .true.,                  &
-           flux_gas_name  = 'co2_sat_flux',          &
-           flux_gas_type  = 'air_sea_gas_flux',      &
-           flux_gas_molwt = WTMCO2,                  &
-           flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),&
+      call g_tracer_add(tracer_list,package_name,                     &
+           name           = 'dic_sat',                                &
+           longname       = 'Saturation Dissolved Inorganic Carbon',  &
+           units          = 'mol/kg',                                 &
+           prog           = .true.,                                   &
+           flux_gas       = .true.,                                   &
+           flux_gas_name  = 'co2_sat_flux',                           &
+           flux_gas_type  = 'air_sea_gas_flux',                       &
+           flux_gas_molwt = WTMCO2,                                   &
+           flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /),         &
            flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-           flux_param     = (/12.011e-03  /),        &
-           init_value     = 0.001)
+           flux_param     = (/12.011e-03  /),                         &
+           init_value     = 0.001                                      )
       !
       !Diagnostic tracers
       !
@@ -2478,20 +2514,20 @@ write (stdlogunit, generic_bling_nml)
       if (do_14c) then                                        !<<RADIOCARBON
       !       D14IC (Dissolved inorganic radiocarbon)
       !
-      call g_tracer_add(tracer_list,package_name,       &
-         name       = 'di14c',                          &
-         longname   = 'Dissolved Inorganic Radiocarbon',&
-         units      = 'mol/kg',                         &
-         prog       = .true.,                           &
-         flux_gas       = .true.,                       &
-         flux_gas_name  = 'c14o2_flux',                 &
-         flux_gas_type  = 'air_sea_gas_flux',           &
-         flux_gas_molwt = WTMCO2,                       &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),   &
+      call g_tracer_add(tracer_list,package_name,           &
+         name       = 'di14c',                              &
+         longname   = 'Dissolved Inorganic Radiocarbon',    &
+         units      = 'mol/kg',                             &
+         prog       = .true.,                               &
+         flux_gas       = .true.,                           &
+         flux_gas_name  = 'c14o2_flux',                     &
+         flux_gas_type  = 'air_sea_gas_flux',               &
+         flux_gas_molwt = WTMCO2,                           &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /), &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-         flux_param     = (/14.e-03  /),                &
-         flux_bottom    = .true.,                       &
-         init_value     = 0.001)
+         flux_param     = (/14.e-03  /),                    &
+         flux_bottom    = .true.,                           &
+         init_value     = 0.001                              )
       !
       !       DO14C (Dissolved organic radiocarbon)
       !
@@ -5012,14 +5048,22 @@ write (stdlogunit, generic_bling_nml)
        !---------------------------------------------------------------------
        !     CO2
        !---------------------------------------------------------------------
-
+  
        !---------------------------------------------------------------------
        !  Compute the Schmidt number of CO2 in seawater using the
        !  formulation presented by Wanninkhof (1992, J. Geophys. Res., 97,
        !  7373-7382).
        !---------------------------------------------------------------------
-       co2_sc_no(i,j) = bling%a1_co2 + ST * (bling%a2_co2 + ST * (bling%a3_co2 + ST * bling%a4_co2)) * &
+       if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+         co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + ST*bling%a4_co2)) * & 
             grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CNT entered W92 for CO2 SNo')
+       else if (trim(as_param_bling) == 'W14') then
+         co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + & 
+                                             ST*(bling%a4_co2 + ST*bling%a5_co2)  ) ) * &
+            grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CNT entered W14 for CO2 SNo')
+       endif
 !       sc_no_term = sqrt(660.0 / (sc_co2 + epsln))
 !
 !       co2_alpha(i,j) = co2_alpha(i,j)* sc_no_term * bling%Rho_0 !nnz: MOM has rho(i,j,1,tau)
@@ -5041,7 +5085,6 @@ write (stdlogunit, generic_bling_nml)
     call g_tracer_set_values(tracer_list,'dic','sc_no',co2_sc_no,isd,jsd)
 
     endif                                                     !CARBON CYCLE>>
-
 
     call g_tracer_get_values(tracer_list,'o2','alpha', o2_alpha ,isd,jsd)
     call g_tracer_get_values(tracer_list,'o2','csurf', o2_csurf ,isd,jsd)
@@ -5095,8 +5138,16 @@ write (stdlogunit, generic_bling_nml)
        ! In 'ocmip2_generic' atmos_ocean_fluxes.F90 coupler formulation,
        ! the schmidt number is carried in explicitly
        !
-       o2_sc_no(i,j)  = bling%a1_o2  + ST * (bling%a2_o2  + ST * (bling%a3_o2  + ST * bling%a4_o2 )) * &
+       if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+         o2_sc_no(i,j)  = bling%a1_o2 + ST * (bling%a2_o2 + ST * (bling%a3_o2 + ST * bling%a4_o2 )) * &
             grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CCNT entered W92 for O2 SNo')
+       else if (trim(as_param_bling) == 'W14') then
+         o2_sc_no(i,j) = bling%a1_o2 + ST*(bling%a2_o2 + ST*(bling%a3_o2 + &
+                                            ST*(bling%a4_o2 + ST*bling%a5_o2)  ) ) * &
+            grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CCNT entered W14 for O2 SNo')
+       endif
        !
        !      renormalize the alpha value for atm o2
        !      data table override for o2_flux_pcair_atm is now set to 0.21
@@ -5127,9 +5178,15 @@ write (stdlogunit, generic_bling_nml)
          !---------------------------------------------------------------------
 
          sal = SSS(i,j) ; ST = SST(i,j)
-         co2_sc_no(i,j) = bling%a1_co2 + ST * (bling%a2_co2 + ST * (bling%a3_co2 + ST * bling%a4_co2)) * &
-            grid_tmask(i,j,1)
-       
+         if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+           co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + ST*bling%a4_co2)) * & 
+              grid_tmask(i,j,1)
+         else if (trim(as_param_bling) == 'W14') then
+           co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + & 
+                                               ST*(bling%a4_co2 + ST*bling%a5_co2)  ) ) * &
+              grid_tmask(i,j,1)
+         endif
+
          c14o2_alpha(i,j) = c14o2_alpha(i,j) * bling%Rho_0 
          c14o2_csurf(i,j) = c14o2_csurf(i,j) * bling%Rho_0 
 

--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -45,8 +45,10 @@ module generic_CFC
   use coupler_types_mod, only: coupler_2d_bc_type
   use field_manager_mod, only: fm_string_len
   use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
-  use time_manager_mod, only : time_type
-  use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
+  use time_manager_mod, only: time_type
+  use fm_util_mod,      only: fm_util_start_namelist, fm_util_end_namelist  
+  use fms_mod,          only: open_namelist_file, check_nml_error, close_file
+  use fms_mod,          only: stdout, stdlog, mpp_pe, mpp_root_pe
 
   use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list
   use g_tracer_utils, only : g_tracer_add,g_tracer_add_param, g_tracer_set_files
@@ -56,7 +58,7 @@ module generic_CFC
 
   use g_tracer_utils, only : g_diag_type, g_diag_field_add
   use g_tracer_utils, only : register_diag_field=>g_register_diag_field
-  use g_tracer_utils, only : g_send_data
+  use g_tracer_utils, only : g_send_data, is_root_pe
 
   implicit none ; private
 
@@ -71,10 +73,12 @@ module generic_CFC
   public generic_CFC_update_from_source
   public generic_CFC_set_boundary_values
   public generic_CFC_end
+  public as_param_cfc
 
-  !The following logical for using this module is overwritten 
-  ! by generic_tracer_nml namelist
+  !The following variables for using this module
+  ! are overwritten by generic_tracer_nml namelist
   logical, save :: do_generic_CFC = .false.
+  character(len=10), save :: as_param_cfc   = 'gfdl_cmip6'
 
   real, parameter :: epsln=1.0e-30
   real, parameter :: missing_value1=-1.0e+10
@@ -88,25 +92,18 @@ module generic_CFC
   !nnz: Find out about the timing overhead for using type%x rather than x
 
   type generic_CFC_params
-     !real :: a1_11, a2_11, a3_11, a4_11   ! Coefficients in the calculation of the
-     !real :: a1_12, a2_12, a3_12, a4_12   ! CFC11 and CFC12 Schmidt numbers, in
-     ! units of ND, degC-1, degC-2, degC-3.
-     real :: d1_11, d2_11, d3_11, d4_11   ! Coefficients in the calculation of the
-     real :: d1_12, d2_12, d3_12, d4_12   ! CFC11 and CFC12 solubilities, in units
-                                          ! of ND, K-1, log(K)^-1, K-2.
-     real :: e1_11, e2_11, e3_11          ! More coefficients in the calculation of
-     real :: e1_12, e2_12, e3_12          ! the CFC11 and CFC12 solubilities, in
+     real :: a1_11, a2_11, a3_11, a4_11   ! Coefficients in the calculation of the
+     real :: a1_12, a2_12, a3_12, a4_12   ! CFC11 and CFC12 Schmidt numbers, in
+     
+     real :: b1_11, b2_11, b3_11          ! More coefficients in the calculation of
+     real :: b1_12, b2_12, b3_12          ! the CFC11 and CFC12 solubilities, in
                                           ! units of PSU-1, PSU-1 K-1, PSU-1 K-2.
+
      real :: sA_11, sB_11, sC_11, sD_11, sE_11   ! Coefficients in the calculation of the
      real :: sA_12, sB_12, sC_12, sD_12, sE_12   ! CFC11 and CFC12 Schmidt numbers, in
                                                  ! units of ND, degC-1, degC-2, degC-3.
-     !real :: A1_11, A2_11, A3_11                ! Coefficients in the calculation of the
-     !real :: A1_12, A2_12, A3_12                ! CFC11 and CFC12 solubilities, in units
-                                                 ! of ND, K-1, log(K)^-1, K-2.
-     !real :: B1_11, B2_11, B3_11                ! More coefficients in the calculation of
-     !real :: B1_12, B2_12, B3_12                ! the CFC11 and CFC12 solubilities, in
-                                                 ! units of PSU-1, PSU-1 K-1, PSU-1 K-2.
-      real :: Rho_0
+     real :: Rho_0
+
      character(len=fm_string_len) :: ice_restart_file
      character(len=fm_string_len) :: ocean_restart_file,IC_file
   end type generic_CFC_params
@@ -254,66 +251,74 @@ contains
     !         for CFC11 and CFC12
     !-----------------------------------------------------------------------
     !    g_tracer_add_param(name   , variable   ,  default_value)
-    !call g_tracer_add_param('a1_11', param%a1_11,  3501.8)
-    !call g_tracer_add_param('a2_11', param%a2_11, -210.31)
-    !call g_tracer_add_param('a3_11', param%a3_11,  6.1851)
-    !call g_tracer_add_param('a4_11', param%a4_11, -0.07513)
-    !call g_tracer_add_param('a1_12', param%a1_12,  3845.4)
-    !call g_tracer_add_param('a2_12', param%a2_12, -228.95)
-    !call g_tracer_add_param('a3_12', param%a3_12,  6.1908)
-    !call g_tracer_add_param('a4_12', param%a4_12, -0.067430)
-    !-----------------------------------------------------------------------
-    !     Schmidt number coefficients
-    !      Use coefficients given by Wanninkhof (2014), L&O: Methods, 12, 351-362
-    !         for CFC11 and CFC12
-    !-----------------------------------------------------------------------
-    !    g_tracer_add_param(name   , variable   ,  default_value)
-    call g_tracer_add_param('sA_11', param%sA_11,  3579.2)
-    call g_tracer_add_param('sB_11', param%sB_11, -222.63)
-    call g_tracer_add_param('sC_11', param%sC_11,  7.5749)
-    call g_tracer_add_param('sD_11', param%sD_11, -0.14595)
-    call g_tracer_add_param('sE_11', param%sE_11,  0.0011874)
-    call g_tracer_add_param('sA_12', param%sA_12,  3828.1)
-    call g_tracer_add_param('sB_12', param%sB_12, -249.86)
-    call g_tracer_add_param('sC_12', param%sC_12,  8.7603)
-    call g_tracer_add_param('sD_12', param%sD_12, -0.1716)
-    call g_tracer_add_param('sE_12', param%sE_12,  0.001408)
+    if (trim(as_param_cfc) == 'W92') then
+        call g_tracer_add_param('sA_11', param%sA_11,  3501.8)
+        call g_tracer_add_param('sB_11', param%sB_11, -210.31)
+        call g_tracer_add_param('sC_11', param%sC_11,  6.1851)
+        call g_tracer_add_param('sD_11', param%sD_11, -0.07513)
+        call g_tracer_add_param('sE_11', param%sE_11,  0.0)      ! Not used for W92
+        call g_tracer_add_param('sA_12', param%sA_12,  3845.4)
+        call g_tracer_add_param('sB_12', param%sB_12, -228.95)
+        call g_tracer_add_param('sC_12', param%sC_12,  6.1908)
+        call g_tracer_add_param('sD_12', param%sD_12, -0.067430)
+        call g_tracer_add_param('sE_12', param%sE_12,  0.0)      ! Not used for W92
+        if (is_root_pe()) call mpp_error(NOTE,'generic_cfc: using Schmidt number coefficients for W92')
+    else if ((trim(as_param_cfc) == 'W14') .or. (trim(as_param_cfc) == 'gfdl_cmip6')) then 
+        call g_tracer_add_param('sA_11', param%sA_11,  3579.2)
+        call g_tracer_add_param('sB_11', param%sB_11, -222.63)
+        call g_tracer_add_param('sC_11', param%sC_11,  7.5749)
+        call g_tracer_add_param('sD_11', param%sD_11, -0.14595)
+        call g_tracer_add_param('sE_11', param%sE_11,  0.0011874)
+        call g_tracer_add_param('sA_12', param%sA_12,  3828.1)
+        call g_tracer_add_param('sB_12', param%sB_12, -249.86)
+        call g_tracer_add_param('sC_12', param%sC_12,  8.7603)
+        call g_tracer_add_param('sD_12', param%sD_12, -0.1716)
+        call g_tracer_add_param('sE_12', param%sE_12,  0.001408)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_cfc: using Schmidt number coefficients for W14')
+    else
+        call mpp_error(FATAL,'Unable to set Schmidt number coefficients for as_param '//trim(as_param_cfc))
+    endif
+
     !-----------------------------------------------------------------------
     !     Solubility coefficients for alpha in mol/l/atm
     !      (1) for CFC11, (2) for CFC12
     !     after Warner and Weiss (1985) DSR, vol 32 for CFC11 and CFC12
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('d1_11', param%d1_11, -229.9261)
-    call g_tracer_add_param('d2_11', param%d2_11,  319.6552)
-    call g_tracer_add_param('d3_11', param%d3_11,  119.4471)
-    call g_tracer_add_param('d4_11', param%d4_11, -1.39165)
-    call g_tracer_add_param('e1_11', param%e1_11, -0.142382)
-    call g_tracer_add_param('e2_11', param%e2_11,  0.091459)
-    call g_tracer_add_param('e3_11', param%e3_11, -0.0157274)
-    call g_tracer_add_param('d1_12', param%d1_12, -218.0971)
-    call g_tracer_add_param('d2_12', param%d2_12,  298.9702)
-    call g_tracer_add_param('d3_12', param%d3_12,  113.8049)
-    call g_tracer_add_param('d4_12', param%d4_12, -1.39165)
-    call g_tracer_add_param('e1_12', param%e1_12, -0.143566)
-    call g_tracer_add_param('e2_12', param%e2_12,  0.091015)
-    call g_tracer_add_param('e3_12', param%e3_12, -0.0153924)
-    !-----------------------------------------------------------------------
-    !     Solubility coefficients for alpha in mol/l/atm
-    !      (1) for CFC11, (2) for CFC12
-    !     after Wanninkhof (2014), L&O: Methods, 12, 351-362
-    !-----------------------------------------------------------------------
-    !call g_tracer_add_param('A1_11', param%A1_11, -134.1536)
-    !call g_tracer_add_param('A2_11', param%A2_11,  203.2156)
-    !call g_tracer_add_param('A3_11', param%A3_11,  56.2320)
-    !call g_tracer_add_param('B1_11', param%B1_11, -0.144449)
-    !call g_tracer_add_param('B2_11', param%B2_11,  0.092952)
-    !call g_tracer_add_param('B3_11', param%B3_11, -0.0159977)
-    !call g_tracer_add_param('A1_12', param%A1_12, -122.3246)
-    !call g_tracer_add_param('A2_12', param%A2_12,  182.5306)
-    !call g_tracer_add_param('A3_12', param%A3_12,  50.5898)
-    !call g_tracer_add_param('B1_12', param%B1_12, -0.145633)
-    !call g_tracer_add_param('B2_12', param%B2_12,  0.092509)
-    !call g_tracer_add_param('B3_12', param%B3_12, -0.0156627)
+    if ((trim(as_param_cfc) == 'W92') .or. (trim(as_param_cfc) == 'gfdl_cmip6')) then
+        call g_tracer_add_param('A1_11', param%A1_11, -229.9261)
+        call g_tracer_add_param('A2_11', param%A2_11,  319.6552)
+        call g_tracer_add_param('A3_11', param%A3_11,  119.4471)
+        call g_tracer_add_param('A4_11', param%A4_11, -1.39165)
+        call g_tracer_add_param('B1_11', param%B1_11, -0.142382)
+        call g_tracer_add_param('B2_11', param%B2_11,  0.091459)
+        call g_tracer_add_param('B3_11', param%B3_11, -0.0157274)
+        call g_tracer_add_param('A1_12', param%A1_12, -218.0971)
+        call g_tracer_add_param('A2_12', param%A2_12,  298.9702)
+        call g_tracer_add_param('A3_12', param%A3_12,  113.8049)
+        call g_tracer_add_param('A4_12', param%A4_12, -1.39165)
+        call g_tracer_add_param('B1_12', param%B1_12, -0.143566)
+        call g_tracer_add_param('B2_12', param%B2_12,  0.091015)
+        call g_tracer_add_param('B3_12', param%B3_12, -0.0153924)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_cfc: using solubility coefficients for W92')
+    else if (trim(as_param_cfc) == 'W14') then
+        call g_tracer_add_param('A1_11', param%A1_11, -134.1536)
+        call g_tracer_add_param('A2_11', param%A2_11,  203.2156)
+        call g_tracer_add_param('A3_11', param%A3_11,  56.2320)
+        call g_tracer_add_param('A4_11', param%A4_11,  0.0)        ! Not used in W14
+        call g_tracer_add_param('B1_11', param%B1_11, -0.144449)
+        call g_tracer_add_param('B2_11', param%B2_11,  0.092952)
+        call g_tracer_add_param('B3_11', param%B3_11, -0.0159977)
+        call g_tracer_add_param('A1_12', param%A1_12, -122.3246)
+        call g_tracer_add_param('A2_12', param%A2_12,  182.5306)
+        call g_tracer_add_param('A3_12', param%A3_12,  50.5898)
+        call g_tracer_add_param('A4_12', param%A4_12,  0.0)        ! Not used in W14
+        call g_tracer_add_param('B1_12', param%B1_12, -0.145633)
+        call g_tracer_add_param('B2_12', param%B2_12,  0.092509)
+        call g_tracer_add_param('B3_12', param%B3_12, -0.0156627)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_cfc: using solubility coefficients for W14')
+    else
+        call mpp_error(FATAL,'Unable to set solubility coefficients for as_param '//trim(as_param_cfc))
+    endif
 
     !  Rho_0 is used in the Boussinesq
     !  approximation to calculations of pressure and
@@ -336,9 +341,19 @@ contains
   subroutine user_add_tracers(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
 
-
     character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+    real :: as_coeff_cfc
 
+    if ((trim(as_param_cfc) == 'W92') .or. (trim(as_param_cfc) == 'gfdl_cmip6')) then
+        ! Air-sea gas exchange coefficient presented in OCMIP2 protocol.
+        ! Value is 0.337 cm/hr in units of m/s.
+        as_coeff_cfc = 9.36e-7
+    else if (trim(as_param_cfc) == 'W14') then
+        ! Value is 0.251 cm/hr in units of m/s
+        as_coeff_cfc = 6.972e-7
+    else
+        call mpp_error(FATAL,'Unable to set wind speed coefficient coefficients for as_param '//trim(as_param_cfc))
+    endif
 
     call g_tracer_start_param_list(package_name)!nnz: Does this append?
     call g_tracer_add_param('ice_restart_file'   , param%ice_restart_file   , 'ice_ocmip2_cfc.res.nc')
@@ -362,33 +377,34 @@ contains
     !diag_tracers: none
     !
     !cfc12
-    call g_tracer_add(tracer_list,package_name,&
-         name       = 'cfc12',               &
-         longname   = 'Moles Per Unit Mass of CFC-12 in sea water',          &
-         units      = 'mol/kg',                        &
-         prog       = .true.,                          &
-         requires_src_info  = .false.,                 &
-         flux_gas       = .true.,                      &
-         flux_gas_type  = 'air_sea_gas_flux_generic',  &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),  &
-         flux_gas_restart_file  = 'ocmip2_cfc_airsea_flux.res.nc', &
+
+    call g_tracer_add(tracer_list,package_name,                      &
+         name       = 'cfc12',                                       &
+         longname   = 'Moles Per Unit Mass of CFC-12 in sea water',  &
+         units      = 'mol/kg',                                      &
+         prog       = .true.,                                        &
+         requires_src_info  = .false.,                               &
+         flux_gas       = .true.,                                    &
+         flux_gas_type  = 'air_sea_gas_flux_generic',                &
+         flux_gas_param = (/ as_coeff_cfc, 9.7561e-06 /),            &
+         flux_gas_restart_file  = 'ocmip2_cfc_airsea_flux.res.nc',   &
          standard_name = "mole_concentration_of_cfc12_in_sea_water", &
-         diag_field_units = 'mol m-3', &
+         diag_field_units = 'mol m-3',                               &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
 
     !cfc11
-    call g_tracer_add(tracer_list,package_name,        &
-         name       = 'cfc11',                        &
-         longname   = 'Moles Per Unit Mass of CFC-11 in sea water',          &
-         units      = 'mol/kg',                        &
-         prog       = .true.,                          &
-         requires_src_info  = .false.,                 &
-         flux_gas       = .true.,                      &
-         flux_gas_type  = 'air_sea_gas_flux_generic',  &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),  &
-         flux_gas_restart_file  = 'ocmip2_cfc_airsea_flux.res.nc', &
+    call g_tracer_add(tracer_list,package_name,                      &
+         name       = 'cfc11',                                       &
+         longname   = 'Moles Per Unit Mass of CFC-11 in sea water',  &
+         units      = 'mol/kg',                                      &
+         prog       = .true.,                                        &
+         requires_src_info  = .false.,                               &
+         flux_gas       = .true.,                                    &
+         flux_gas_type  = 'air_sea_gas_flux_generic',                &
+         flux_gas_param = (/ as_coeff_cfc, 9.7561e-06 /),            &
+         flux_gas_restart_file  = 'ocmip2_cfc_airsea_flux.res.nc',   &
          standard_name = "mole_concentration_of_cfc11_in_sea_water", &
-         diag_field_units = 'mol m-3', &
+         diag_field_units = 'mol m-3',                               &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
 
 
@@ -555,53 +571,41 @@ contains
        !
        !       Use Bullister and Wisegavger for CCl4
        !---------------------------------------------------------------------
-
-       !nnz: MOM hmask=grid_tmask(i,j,1), GOLD hmask=G%hmask 
-       alpha_11 = conv_fac * grid_tmask(i,j,1) * &
-            exp(param%d1_11 + param%d2_11/ta + param%d3_11*log(ta) + param%d4_11*ta*ta +&
-            sal * ((param%e3_11 * ta + param%e2_11) * ta + param%e1_11)&
-            )
-
-       alpha_12 = conv_fac * grid_tmask(i,j,1) * &
-            exp(param%d1_12 + param%d2_12/ta + param%d3_12*log(ta) + param%d4_12*ta*ta +&
-            sal * ((param%e3_12 * ta + param%e2_12) * ta + param%e1_12)&
-            )
-       !---------------------------------------------------------------------
-       !     Calculate solubilities
-       !       Use Warner and Weiss (1985) DSR, vol 32, final result
-       !       in mol/l/atm (note, atmospheric data may be in 1 part per trillion 1e-12, pptv)
-       !
-       !       Use Bullister and Wisegavger for CCl4
-       !---------------------------------------------------------------------
-
-       !nnz: MOM hmask=grid_tmask(i,j,1), GOLD hmask=G%hmask 
-       !alpha_11 = conv_fac * grid_tmask(i,j,1) * &
-       !     exp(param%A1_11 + param%A2_11/ta + param%A3_11*log(ta) +&
-       !     sal * (param%B1_11 + ta * (param%B2_11 + ta * param%B3_11))&
-       !     )
-
-       !alpha_12 = conv_fac * grid_tmask(i,j,1) * &
-       !     exp(param%A1_12 + param%A2_12/ta + param%A3_12*log(ta) +&
-       !     sal * (param%B1_12 + ta * (param%B2_12 + ta * param%B3_12))&
-       !     )
+       if ((trim(as_param_cfc) == 'W92') .or. (trim(as_param_cfc) == 'gfdl_cmip6')) then
+           alpha_11 = conv_fac * grid_tmask(i,j,1) * &
+                exp(param%A1_11 + param%A2_11/ta + param%A3_11*log(ta) + param%A4_11*ta*ta +&
+                sal * ((param%B3_11 * ta + param%B2_11) * ta + param%B1_11)&
+                )
+           alpha_12 = conv_fac * grid_tmask(i,j,1) * &
+                exp(param%A1_12 + param%A2_12/ta + param%A3_12*log(ta) + param%A4_12*ta*ta +&
+                sal * ((param%B3_12 * ta + param%B2_12) * ta + param%B1_12)&
+                )
+       else if (trim(as_param_cfc) == 'W14') then
+           alpha_11 = conv_fac * grid_tmask(i,j,1) * &
+                exp(param%A1_11 + param%A2_11/ta + param%A3_11*log(ta) +&
+                sal * (param%B1_11 + ta * (param%B2_11 + ta * param%B3_11))&
+                )
+           alpha_12 = conv_fac * grid_tmask(i,j,1) * &
+                exp(param%A1_12 + param%A2_12/ta + param%A3_12*log(ta) +&
+                sal * (param%B1_12 + ta * (param%B2_12 + ta * param%B3_12))&
+                )
+       endif
 
        !---------------------------------------------------------------------
        !     Calculate Schmidt numbers
        !      use coefficients given by Zheng et al (1998), JGR vol 103, C1
        !---------------------------------------------------------------------
-       !sc_no_11(i,j) = param%a1_11 + SST * (param%a2_11 + SST * (param%a3_11 + SST * param%a4_11)) * &
-       !     grid_tmask(i,j,1)
-       !sc_no_12(i,j) = param%a1_12 + SST * (param%a2_12 + SST * (param%a3_12 + SST * param%a4_12)) * &
-       !     grid_tmask(i,j,1)
-
-       !---------------------------------------------------------------------
-       !     Calculate Schmidt numbers
-       !      use coefficients given by Zheng et al (1998), JGR vol 103, C1
-       !---------------------------------------------------------------------
-       sc_no_11(i,j) = param%sA_11 + SST * (param%sB_11 + SST * (param%sC_11 + SST * (param%sD_11 + &
-            SST * param%sE_11))) * grid_tmask(i,j,1)
-       sc_no_12(i,j) = param%sA_12 + SST * (param%sB_12 + SST * (param%sC_12 + SST * (param%sD_12 + &
-            SST * param%sE_12))) * grid_tmask(i,j,1)
+       if (trim(as_param_cfc) == 'W92') then
+           sc_no_11(i,j) = param%sA_11 + SST * (param%sB_11 + SST * (param%sC_11 + SST * param%sD_11)) * &
+                grid_tmask(i,j,1)
+           sc_no_12(i,j) = param%sA_12 + SST * (param%sB_12 + SST * (param%sC_12 + SST * param%sD_12)) * &
+                grid_tmask(i,j,1)
+       else if ((trim(as_param_cfc) == 'W14') .or. (trim(as_param_cfc) == 'gfdl_cmip6')) then
+           sc_no_11(i,j) = param%sA_11 + SST * (param%sB_11 + SST * (param%sC_11 + SST * (param%sD_11 + &
+                SST * param%sE_11))) * grid_tmask(i,j,1)
+           sc_no_12(i,j) = param%sA_12 + SST * (param%sB_12 + SST * (param%sC_12 + SST * (param%sD_12 + &
+                SST * param%sE_12))) * grid_tmask(i,j,1)
+       endif
 
        !sc_no_term = sqrt(660.0 / (sc_11 + epsln))
        !

--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -124,11 +124,22 @@ module generic_CFC
 
   type generic_CFC_type
     integer :: &
-      id_fgcfc11      = -1, &
-      id_fgcfc12      = -1
+      id_fgcfc11      = -1,    &
+      id_fgcfc12      = -1,    &
+      id_wc_vert_int_cfc11 = -1, &
+      id_wc_vert_int_cfc12 = -1
+
+    real, dimension(:,:), ALLOCATABLE :: &
+      wc_vert_int_cfc11, &
+      wc_vert_int_cfc12
+
     real, dimension (:,:), pointer :: &
       stf_gas_cfc11, &
       stf_gas_cfc12
+
+    real, dimension(:,:,:,:), pointer :: &
+      p_cfc11, &
+      p_cfc12
 
   end type generic_CFC_type
 
@@ -144,8 +155,6 @@ contains
     !Specify all prognostic and diagnostic tracers of this modules.
     call user_add_tracers(tracer_list)
 
-    
-    
   end subroutine generic_CFC_register
 
   ! <SUBROUTINE NAME="generic_CFC_init">
@@ -175,7 +184,7 @@ contains
     call user_add_params
 
     !Allocate and initiate all the private work arrays used by this module.
-    !    call user_allocate_arrays !None for CFC module currently
+    call user_allocate_arrays
 
   end subroutine generic_CFC_init
 
@@ -214,13 +223,32 @@ contains
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          standard_name="surface_downward_mole_flux_of_cfc12")
 
+    vardesc_temp = vardesc("wc_vert_int_cfc11","Total CFC11 vertical integral",'h','1','s','mol m-2','f')
+    cfc%id_wc_vert_int_cfc11 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("wc_vert_int_cfc12","Total CFC12 vertical integral",'h','1','s','mol m-2','f')
+    cfc%id_wc_vert_int_cfc12 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
   end subroutine generic_CFC_register_diag
 
 
   subroutine user_allocate_arrays
-    !Allocate all the private arrays.
-    !None for CFC module currently
+    integer :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,n
+    call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau) 
+
+    allocate(cfc%wc_vert_int_cfc11(isd:ied, jsd:jed))  ; cfc%wc_vert_int_cfc11=0.0
+    allocate(cfc%wc_vert_int_cfc12(isd:ied, jsd:jed))  ; cfc%wc_vert_int_cfc12=0.0
+
   end subroutine user_allocate_arrays
+
+  subroutine user_deallocate_arrays
+
+    deallocate(cfc%wc_vert_int_cfc11)
+    deallocate(cfc%wc_vert_int_cfc12)
+
+  end subroutine user_deallocate_arrays
 
   !
   !   This is an internal sub, not a public interface.
@@ -330,8 +358,6 @@ contains
     !Block Ends: g_tracer_add_param
     !===========
 
-
-
   end subroutine user_add_params
 
   !
@@ -407,7 +433,6 @@ contains
          diag_field_units = 'mol m-3',                               &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
 
-
   end subroutine user_add_tracers
 
   ! <SUBROUTINE NAME="generic_CFC_update_from_coupler">
@@ -456,6 +481,7 @@ contains
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_SF6_update_from_source'
     integer :: isc,iec, jsc,jec,isd,ied,jsd,jed,nk,ntau 
+    integer :: i, j, k
     real, dimension(:,:,:) ,pointer :: grid_tmask
     integer, dimension(:,:),pointer :: mask_coast, grid_kmt
 
@@ -467,6 +493,20 @@ contains
     call g_tracer_get_pointer(tracer_list,'cfc11','stf_gas',cfc%stf_gas_cfc11)
     call g_tracer_get_pointer(tracer_list,'cfc12','stf_gas',cfc%stf_gas_cfc12)
 
+    call g_tracer_get_pointer(tracer_list,'cfc11','field',  cfc%p_cfc11)
+    call g_tracer_get_pointer(tracer_list,'cfc12','field',  cfc%p_cfc12)
+
+    !-- calculate water column vertical integrals
+    do j = jsc, jec ; do i = isc, iec !{
+       cfc%wc_vert_int_cfc11(i,j) = 0.0
+       cfc%wc_vert_int_cfc12(i,j) = 0.0
+    enddo; enddo !} i,j
+
+    do j = jsc, jec ; do i = isc, iec ; do k = 1, nk  !{
+       cfc%wc_vert_int_cfc11(i,j) = cfc%wc_vert_int_cfc11(i,j) + (cfc%p_cfc11(i,j,k,tau) * rho_dzt(i,j,k))
+       cfc%wc_vert_int_cfc12(i,j) = cfc%wc_vert_int_cfc12(i,j) + (cfc%p_cfc12(i,j,k,tau) * rho_dzt(i,j,k))
+    enddo; enddo; enddo  !} i,j,k
+
     if (cfc%id_fgcfc11 .gt. 0)            &
         used = g_send_data(cfc%id_fgcfc11,  cfc%stf_gas_cfc11,   &
         model_time, rmask = grid_tmask(:,:,1),&
@@ -476,6 +516,16 @@ contains
         used = g_send_data(cfc%id_fgcfc12,  cfc%stf_gas_cfc12,   &
         model_time, rmask = grid_tmask(:,:,1),&
         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+    if (cfc%id_wc_vert_int_cfc11 .gt. 0)       &
+       used = g_send_data(cfc%id_wc_vert_int_cfc11, cfc%wc_vert_int_cfc11, &
+       model_time, rmask = grid_tmask(:,:,1),&
+       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+    if (cfc%id_wc_vert_int_cfc12 .gt. 0)       &
+       used = g_send_data(cfc%id_wc_vert_int_cfc12, cfc%wc_vert_int_cfc12, &
+       model_time, rmask = grid_tmask(:,:,1),&
+       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
     return
   end subroutine generic_CFC_update_from_source
@@ -654,6 +704,8 @@ contains
 
   subroutine generic_CFC_end
     character(len=fm_string_len), parameter :: sub_name = 'generic_CFC_end'
+
+    call user_deallocate_arrays
 
   end subroutine generic_CFC_end
 

--- a/generic_tracers/generic_SF6.F90
+++ b/generic_tracers/generic_SF6.F90
@@ -37,6 +37,8 @@ module generic_SF6
   use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
   use time_manager_mod, only : time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
+  use fms_mod,          only: open_namelist_file, check_nml_error, close_file
+  use fms_mod,          only: stdout, stdlog, mpp_pe, mpp_root_pe
 
   use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list
   use g_tracer_utils, only : g_tracer_add,g_tracer_add_param, g_tracer_set_files
@@ -46,7 +48,7 @@ module generic_SF6
 
   use g_tracer_utils, only : g_diag_type, g_diag_field_add
   use g_tracer_utils, only : register_diag_field=>g_register_diag_field
-  use g_tracer_utils, only : g_send_data
+  use g_tracer_utils, only : g_send_data, is_root_pe
 
   implicit none ; private
 
@@ -61,10 +63,12 @@ module generic_SF6
   public generic_SF6_update_from_source
   public generic_SF6_set_boundary_values
   public generic_SF6_end
+  public as_param_sf6
 
-  !The following logical for using this module is overwritten 
-  ! by generic_tracer_nml namelist
+  !The following variables for using this module
+  ! are overwritten by generic_tracer_nml namelist
   logical, save :: do_generic_SF6 = .false.
+  character(len=10), save :: as_param_SF6   = 'gfdl_cmip6'
 
   real, parameter :: epsln=1.0e-30
   real, parameter :: missing_value1=-1.0e+10
@@ -78,18 +82,12 @@ module generic_SF6
   !nnz: Find out about the timing overhead for using type%x rather than x
 
   type generic_SF6_params
-     real :: d1, d2, d3, d4   ! Coefficients in the calculation of the
-                              ! SF6 solubility, in units of ND, K-1, log(K)^-1, K-2.
-
-     real :: e1, e2, e3       ! More coefficients in the calculation of the 
-                              ! SF6 solubility, in units of PSU-1, PSU-1 K-1, PSU-1 K-2.
-
      real :: sA, sB, sC, sD, sE   ! Coefficients in the calculation of SF6
                                   ! Schmidt number, in units of ND, degC-1, degC-2, degC-3.
-    !real :: A1, A2, A3           ! Coefficients in the calculation of SF6
-    !                             ! solubility, in units of ND, K-1, log(K)^-1.
-    !real :: B1, B2, B3           ! More coefficients in the calculation of SF6
-    !                             ! solubility, in units of PSU-1, PSU-1 K-1, PSU-1 K-2.
+     real :: A1, A2, A3, A4       ! Coefficients in the calculation of SF6
+                                  ! solubility, in units of ND, K-1, log(K)^-1.
+     real :: B1, B2, B3           ! More coefficients in the calculation of SF6
+                                  ! solubility, in units of PSU-1, PSU-1 K-1, PSU-1 K-2.
       real :: Rho_0
      character(len=fm_string_len) :: ice_restart_file
      character(len=fm_string_len) :: ocean_restart_file,IC_file
@@ -231,11 +229,17 @@ contains
     !         for SF6
     !-----------------------------------------------------------------------
     !    g_tracer_add_param(name   , variable   ,  default_value)
-    call g_tracer_add_param('sA', param%sA,  3177.5)
-    call g_tracer_add_param('sB', param%sB, -200.57)
-    call g_tracer_add_param('sC', param%sC,  6.8865)
-    call g_tracer_add_param('sD', param%sD, -0.13335)
-    call g_tracer_add_param('sE', param%sE,  0.0010877)
+    if ((trim(as_param_SF6) == 'W14') .or. (trim(as_param_SF6) == 'gfdl_cmip6')) then
+        call g_tracer_add_param('sA', param%sA,  3177.5)
+        call g_tracer_add_param('sB', param%sB, -200.57)
+        call g_tracer_add_param('sC', param%sC,  6.8865)
+        call g_tracer_add_param('sD', param%sD, -0.13335)
+        call g_tracer_add_param('sE', param%sE,  0.0010877)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_sf6: Using Schmidt number coefficients for W14')
+    else
+        call mpp_error(FATAL,'generic_sf6: Unable to set Schmidt number coefficients for as_param '//trim(as_param_SF6))
+    endif
+
     !-----------------------------------------------------------------------
     !     Solubility coefficients for alpha in mol/l/atm
     !      for SF6
@@ -243,24 +247,27 @@ contains
     !
     ! NOTE: Constants below DO NOT match those in Orr et al. 2017 GMDD
     !-----------------------------------------------------------------------
-    !call g_tracer_add_param('A1', param%A1, -96.5975)
-    !call g_tracer_add_param('A2', param%A2,  139.883)
-    !call g_tracer_add_param('A3', param%A3,  37.8193)
-    !call g_tracer_add_param('B1', param%B1,  0.0310693)
-    !call g_tracer_add_param('B2', param%B2, -0.0356385)
-    !call g_tracer_add_param('B3', param%B3,  0.00743254)
-    !-----------------------------------------------------------------------
-    !     Solubility coefficients for alpha in mol/l/atm
-    !      (1) for CFC11, (2) for CFC12
-    !     after Warner and Weiss (1985) DSR, vol 32 for CFC11 and CFC12
-    !-----------------------------------------------------------------------
-    call g_tracer_add_param('d1', param%d1, -80.0343)
-    call g_tracer_add_param('d2', param%d2,  117.232)
-    call g_tracer_add_param('d3', param%d3,  29.5817)
-    call g_tracer_add_param('d4', param%d4,  0.0)
-    call g_tracer_add_param('e1', param%e1,  0.0335183)
-    call g_tracer_add_param('e2', param%e2, -0.0373942)
-    call g_tracer_add_param('e3', param%e3,  0.00774862)
+    if ((trim(as_param_SF6) == 'W92') .or. (trim(as_param_SF6) == 'gfdl_cmip6')) then
+        call g_tracer_add_param('A1', param%A1, -80.0343)
+        call g_tracer_add_param('A2', param%A2,  117.232)
+        call g_tracer_add_param('A3', param%A3,  29.5817)
+        call g_tracer_add_param('A4', param%A4,  0.0)        ! Not used for W92
+        call g_tracer_add_param('B1', param%B1,  0.0335183)
+        call g_tracer_add_param('B2', param%B2, -0.0373942)
+        call g_tracer_add_param('B3', param%B3,  0.00774862)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_sf6: using solubility coefficients for W92')
+    else if (trim(as_param_SF6) == 'W14') then
+        call g_tracer_add_param('A1', param%A1, -96.5975)
+        call g_tracer_add_param('A2', param%A2,  139.883)
+        call g_tracer_add_param('A3', param%A3,  37.8193)
+        call g_tracer_add_param('A4', param%A4,  0.0)        ! Not used for W92
+        call g_tracer_add_param('B1', param%B1,  0.0310693)
+        call g_tracer_add_param('B2', param%B2, -0.0356385)
+        call g_tracer_add_param('B3', param%B3,  0.00743254)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_sf6: using solubility coefficients for W14')
+    else
+        call mpp_error(FATAL,'Unable to set solubility coefficients for as_param '//trim(as_param_SF6))
+    endif
 
 
     !  Rho_0 is used in the Boussinesq
@@ -284,9 +291,19 @@ contains
   subroutine user_add_tracers(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
 
-
     character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+    real :: as_coeff_SF6
 
+    if ((trim(as_param_SF6) == 'W92') .or. (trim(as_param_SF6) == 'gfdl_cmip6')) then
+        ! Air-sea gas exchange coefficient presented in OCMIP2 protocol.
+        ! Value is 0.337 cm/hr in units of m/s.
+        as_coeff_SF6 = 9.36e-7
+    else if (trim(as_param_SF6) == 'W14') then
+        ! Value is 0.251 cm/hr in units of m/s
+        as_coeff_SF6 = 6.972e-7
+    else
+        call mpp_error(FATAL,'Unable to set wind speed coefficient coefficients for as_param '//trim(as_param_SF6))
+    endif
 
     call g_tracer_start_param_list(package_name)!nnz: Does this append?
     call g_tracer_add_param('ice_restart_file'   , param%ice_restart_file   , 'ice_ocmip_sf6.res.nc')
@@ -317,7 +334,7 @@ contains
          prog = .true.,                                           &
          flux_gas = .true.,                                       &
          flux_gas_type  = 'air_sea_gas_flux_generic',             &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),             &
+         flux_gas_param = (/ as_coeff_sf6, 9.7561e-06 /),         &
          flux_gas_restart_file  = 'ocmip_sf6_airsea_flux.res.nc', &
          standard_name = "mole_concentration_of_sulfur_hexafluoride_in_sea_water", &
          diag_field_units = 'mol m-3', &
@@ -470,29 +487,28 @@ contains
 
        !---------------------------------------------------------------------
        !     Calculate solubilities
-       !       Use Warner and Weiss (1985) DSR, vol 32, final result
-       !       in mol/l/atm (note, atmospheric data may be in 1 part per trillion 1e-12, pptv)
-       !
-       !       Use Bullister and Wisegavger for CCl4
        !---------------------------------------------------------------------
 
-       !nnz: MOM hmask=grid_tmask(i,j,1), GOLD hmask=G%hmask 
-       !alpha = conv_fac * grid_tmask(i,j,1) * &
-       !     exp(param%A1 + param%A2/ta + param%A3*log(ta) +&
-       !     sal * (param%B1 + ta * (param%B2 + ta * param%B3))&
-       !     )
+       if ((trim(as_param_sf6) == 'W92') .or. (trim(as_param_sf6) == 'gfdl_cmip6')) then
+           alpha = conv_fac * grid_tmask(i,j,1) * &
+               exp(param%A1 + param%A2/ta + param%A3*log(ta) +&
+               sal * (param%B1 + ta * (param%B2 + ta * param%B3))&
+               )
 
-       alpha = conv_fac * grid_tmask(i,j,1) * &
-            exp(param%d1 + param%d2/ta + param%d3*log(ta) + param%d4*ta*ta +&
-            sal * ((param%e3 * ta + param%e2) * ta + param%e1)&
-            )
+       else if (trim(as_param_sf6) == 'W14') then
+           alpha = conv_fac * grid_tmask(i,j,1) * &
+               exp(param%A1 + param%A2/ta + param%A3*log(ta) + param%A4*ta*ta +&
+               sal * ((param%B3 * ta + param%B2) * ta + param%B1)&
+               )
+       endif
 
        !---------------------------------------------------------------------
        !     Calculate Schmidt numbers
-       !      use coefficients given by Zheng et al (1998), JGR vol 103, C1
        !---------------------------------------------------------------------
-       sc_no(i,j) = param%sA + SST * (param%sB + SST * (param%sC + SST * (param%sD + &
-            SST * param%sE))) * grid_tmask(i,j,1)
+       if ((trim(as_param_sf6) == 'W14') .or. (trim(as_param_sf6) == 'gfdl_cmip6')) then
+           sc_no(i,j) = param%sA + SST * (param%sB + SST * (param%sC + SST * (param%sD + &
+               SST * param%sE))) * grid_tmask(i,j,1)
+       endif
 
        !sc_no_term = sqrt(660.0 / (sc + epsln))
        !

--- a/generic_tracers/generic_abiotic.F90
+++ b/generic_tracers/generic_abiotic.F90
@@ -74,16 +74,6 @@
 !! ab_htotal_valid_min = 3.981E-09
 !! ab_htotal_valid_max = 1.259E-08
 !! #
-!! ab_htotal14c_src_file = INPUT/init_ocean_cobalt.res.nc
-!! ab_htotal14c_src_var_name = htotal
-!! ab_htotal14c_src_var_unit = none
-!! ab_htotal14c_dest_var_name =  ab_htotal14c
-!! ab_htotal14c_dest_var_unit = mol kg-1
-!! ab_htotal14c_src_var_record = 1
-!! ab_htotal14c_src_var_gridspec = NONE
-!! ab_htotal14c_valid_min = 3.981E-09
-!! ab_htotal14c_valid_max = 1.259E-08
-!! #
 !! ## divide by 1e6 to convert from umol/kg to mol/kg
 !! dissicabio_src_file = INPUT/Preind_DIC.nc
 !! dissicabio_src_var_name = Preind_DIC
@@ -155,20 +145,17 @@
 !! #-- Non-CMIP Tracer Fields
 !! "generic_abiotic",   "ab_alk",               "ab_alk",               "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "ab_htotal",            "ab_htotal",            "ocean_abiotic","all",.true.,"none", 2
-!! "generic_abiotic",   "ab_htotal14c",         "ab_htotal14c",         "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "ab_po4",               "ab_po4",               "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "ab_sio4",              "ab_sio4",              "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "jdecay_di14c",         "jdecay_di14c",         "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic_z", "ab_alk",               "ab_alk",               "ocean_abiotic_z","all",.true.,"none",2
 !! "generic_abiotic_z", "ab_htotal",            "ab_htotal",            "ocean_abiotic_z","all",.true.,"none",2
-!! "generic_abiotic_z", "ab_htotal14c",         "ab_htotal14c",         "ocean_abiotic_z","all",.true.,"none",2
 !! "generic_abiotic_z", "ab_po4",               "ab_po4",               "ocean_abiotic_z","all",.true.,"none",2
 !! "generic_abiotic_z", "ab_sio4",              "ab_sio4",              "ocean_abiotic_z","all",.true.,"none",2
 
 !! #-- Non-CMIP Surface Fields
 !! "generic_abiotic",   "sfc_ab_alk",           "sfc_ab_alk",           "ocean_abiotic","all",.true.,"none",2
 !! "generic_abiotic",   "sfc_ab_htotal",        "sfc_ab_htotal",        "ocean_abiotic","all",.true.,"none",2
-!! "generic_abiotic",   "sfc_ab_htotal14c",     "sfc_ab_htotal14c",     "ocean_abiotic","all",.true.,"none",2
 !! "generic_abiotic",   "sfc_ab_po4",           "sfc_ab_po4",           "ocean_abiotic","all",.true.,"none",2
 !! "generic_abiotic",   "sfc_ab_sio4",          "sfc_ab_sio4",          "ocean_abiotic","all",.true.,"none",2
 !! 
@@ -269,7 +256,7 @@ namelist /generic_abiotic_nml/ co2_calc
 
      ! Diagnostic Output IDs
      integer :: id_dissicabioos=-1, id_dissi14cabioos=-1
-     integer :: id_sfc_ab_htotal=-1, id_sfc_ab_htotal14c=-1
+     integer :: id_sfc_ab_htotal=-1
      integer :: id_ab_alk=-1, id_ab_po4=-1, id_ab_sio4=-1
      integer :: id_sfc_ab_alk=-1, id_sfc_ab_po4=-1, id_sfc_ab_sio4=-1
      integer :: id_ab_pco2surf=-1, id_ab_p14co2surf=-1
@@ -321,7 +308,7 @@ namelist /generic_abiotic_nml/ co2_calc
 
   type(CO2_dope_vector)        :: CO2_dope_vec
   type(generic_abiotic_params) :: abiotic
-
+ 
 contains
 
   subroutine generic_abiotic_register(tracer_list)
@@ -372,7 +359,7 @@ contains
 
 !> \brief   Initialize the generic abiotic module
 !!
-!! This subroutine adds the dissicabio, dissi14cabio, ab_htotal, and ab_htotal14c tracers to the list of 
+!! This subroutine adds the dissicabio, dissi14cabio, and ab_htotal tracers to the list of 
 !! generic tracers passed to it via utility subroutine g_tracer_add().  Adds all the parameters 
 !! used by this module via utility subroutine g_tracer_add_param(). Allocates all work arrays used 
 !! in the module. 
@@ -458,10 +445,6 @@ contains
 
     vardesc_temp = vardesc("sfc_ab_htotal","Surface Abiotic Htotal",'h','1','s','mol kg-1','f')
     abiotic%id_sfc_ab_htotal = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("sfc_ab_htotal14c","Surface Abiotic Htotal for 14C",'h','1','s','mol kg-1','f')
-    abiotic%id_sfc_ab_htotal14c = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("ab_pco2surf","Oceanic Abiotic pCO2",'h','1','s','uatm','f')
@@ -720,13 +703,6 @@ contains
          prog       = .false.,                        &
          init_value = abiotic%htotal_in )
 
-    call g_tracer_add(tracer_list,package_name,               &
-         name       = 'ab_htotal14c',                         &
-         longname   = 'abiotic H+ ion concentration for 14C', &
-         units      = 'mol/kg',                               &
-         prog       = .false.,                                &
-         init_value = abiotic%htotal14c_in )
-
   end subroutine user_add_tracers
 
 
@@ -762,7 +738,6 @@ contains
          grid_tmask=grid_tmask,grid_mask_coast=mask_coast,grid_kmt=grid_kmt)
 
     call g_tracer_get_values(tracer_list,'ab_htotal',    'field', abiotic%f_htotal       ,isd,jsd,ntau=1)
-    call g_tracer_get_values(tracer_list,'ab_htotal14c', 'field', abiotic%f_htotal14c    ,isd,jsd,ntau=1)
     call g_tracer_get_values(tracer_list,'dissicabio'   ,'field', abiotic%f_dissicabio   ,isd,jsd,ntau=tau)
     call g_tracer_get_values(tracer_list,'dissi14cabio' ,'field', abiotic%f_dissi14cabio ,isd,jsd,ntau=tau)
 
@@ -812,29 +787,22 @@ contains
          co2star=abiotic%abco2_csurf(:,:), alpha=abiotic%abco2_alpha(:,:), &
          pCO2surf=abiotic%abpco2_csurf(:,:))
 
-    call FMS_ocmip2_co2calc(CO2_dope_vec,grid_tmask(:,:,k),&
-         Temp(:,:,k), Salt(:,:,k),                    &
-         abiotic%f_dissi14cabio(:,:,k),                          &
-         abiotic%f_po4(:,:,k),                          &  
-         abiotic%f_sio4(:,:,k),                         &
-         abiotic%f_alk(:,:,k),                          &
-         abiotic%htotal14clo, abiotic%htotal14chi,&
-                                !InOut
-         abiotic%f_htotal14c(:,:,k),                       & 
-                                !OUT
-         co2star=abiotic%ab14co2_csurf(:,:), alpha=abiotic%ab14co2_alpha(:,:), &
-         pCO2surf=abiotic%abp14co2_csurf(:,:))
+    ! Update csurf and alpha based on the atmospheric 14C/12C ratio
 
-    ! Update alpha based on the atmospheric 14C/12C ratio
+    ! The 14C surface concentration (ab14co2_csurf, 14CO2*) is proportional to the 14C surface concentration
+    ! times the ratio of the *ocean* surface carbon concentration (i.e. DI14C/DIC). The 14C solubility (ab14co2_alpha) 
+    ! is proportional to abco2_alpha times the 14C to C ratio of the *atmos* carbon concentration as the 
+    ! ocean carbon solubility mainly depends on temperature and the atmos partial pressure of the gas.
 
     call data_override('OCN', 'delta_14catm', abiotic%delta_14catm(isc:iec,jsc:jec), model_time)
     do j = jsc, jec ; do i = isc, iec  !{
-       abiotic%ab14co2_alpha(i,j) = abiotic%ab14co2_alpha(i,j) * &
+       abiotic%ab14co2_csurf(i,j) = abiotic%abco2_csurf(i,j) * &
+                                   (abiotic%f_dissi14cabio(i,j,1)/(abiotic%f_dissicabio(i,j,1) + epsln))
+       abiotic%ab14co2_alpha(i,j) = abiotic%abco2_alpha(i,j) * &
                                     (1.0 + abiotic%delta_14catm(i,j) * 1.0e-03)
     enddo; enddo ; !} i, j
 
     call g_tracer_set_values(tracer_list,'ab_htotal',   'field',abiotic%f_htotal   ,isd,jsd,ntau=1)
-    call g_tracer_set_values(tracer_list,'ab_htotal14c','field',abiotic%f_htotal14c,isd,jsd,ntau=1)
 
     call g_tracer_set_values(tracer_list,'dissicabio','alpha',abiotic%abco2_alpha    ,isd,jsd)
     call g_tracer_set_values(tracer_list,'dissicabio','csurf',abiotic%abco2_csurf    ,isd,jsd)
@@ -844,7 +812,6 @@ contains
     call g_tracer_get_pointer(tracer_list,'dissicabio',  'field',abiotic%p_dissicabio)
     call g_tracer_get_pointer(tracer_list,'dissi14cabio','field',abiotic%p_dissi14cabio)
     call g_tracer_get_pointer(tracer_list,'ab_htotal','field',abiotic%p_htotal)
-    call g_tracer_get_pointer(tracer_list,'ab_htotal14c','field',abiotic%p_htotal14c)
 
     call g_tracer_get_pointer(tracer_list,'dissicabio','stf_gas',abiotic%stf_gas_dissicabio)
     call g_tracer_get_pointer(tracer_list,'dissi14cabio','stf_gas',abiotic%stf_gas_dissi14cabio)
@@ -920,11 +887,6 @@ contains
 
     if (abiotic%id_sfc_ab_htotal .gt. 0)  &
        used = g_send_data(abiotic%id_sfc_ab_htotal, abiotic%f_htotal(:,:,1),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-
-    if (abiotic%id_sfc_ab_htotal14c .gt. 0)  &
-       used = g_send_data(abiotic%id_sfc_ab_htotal14c, abiotic%f_htotal14c(:,:,1),         &
        model_time, rmask = grid_tmask(:,:,1),&
        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
@@ -1010,7 +972,6 @@ contains
        call g_tracer_get_pointer(tracer_list,'dissi14cabio', 'field', dissi14cabio_field)
 
        call g_tracer_get_values(tracer_list, 'ab_htotal', 'field', htotal_field,isd,jsd,ntau=1)
-       call g_tracer_get_values(tracer_list, 'ab_htotal14c', 'field', htotal14c_field,isd,jsd,ntau=1)
 
        do j = jsc, jec ; do i = isc, iec  !{
           abiotic%htotallo(i,j) = abiotic%htotal_scale_lo * htotal_field(i,j,1)
@@ -1050,31 +1011,21 @@ contains
             co2star=abco2_csurf(:,:), alpha=abco2_alpha(:,:),  &
             pCO2surf=abiotic%abpco2_csurf(:,:))
 
+       ! Update csurf and alpha based on the atmospheric 14C/12C ratio
 
-       call FMS_ocmip2_co2calc(CO2_dope_vec,grid_tmask(:,:,1), &
-            SST(:,:), SSS(:,:),                                &
-            dissi14cabio_field(:,:,1,tau),                     &
-            abiotic%f_po4(:,:,1),                              &  
-            abiotic%f_sio4(:,:,1),                             &
-            abiotic%f_alk(:,:,1),                              &
-            abiotic%htotal14clo, abiotic%htotal14chi,          &
-                                !InOut
-            htotal14c_field(:,:,1),                            &
-                                !Optional In
-            co2_calc=trim(co2_calc),                           & 
-            zt=abiotic%zt(:,:,1),                               & 
-                                !OUT
-            co2star=ab14co2_csurf(:,:), alpha=ab14co2_alpha(:,:),&
-            pCO2surf=abiotic%abp14co2_csurf(:,:))
+       ! The 14C surface concentration (ab14co2_csurf, 14CO2*) is proportional to the 14C surface concentration
+       ! times the ratio of the *ocean* surface carbon concentration (i.e. DI14C/DIC). The 14C solubility (ab14co2_alpha) 
+       ! is proportional to abco2_alpha times the 14C to C ratio of the *atmos* carbon concentration as the 
+       ! ocean carbon solubility mainly depends on temperature and the atmos partial pressure of the gas.
 
-    ! Update alpha based on the atmospheric 14C/12C ratio
-    call data_override('OCN', 'delta_14catm', delta_14catm(isc:iec,jsc:jec), model_time)
-    do j = jsc, jec ; do i = isc, iec  !{
-       ab14co2_alpha(i,j) = ab14co2_alpha(i,j) * (1.0 + delta_14catm(i,j) * 1.0e-03)
-    enddo; enddo ; !} i, j
+       call data_override('OCN', 'delta_14catm', delta_14catm(isc:iec,jsc:jec), model_time)
+       do j = jsc, jec ; do i = isc, iec  !{
+          ab14co2_csurf(i,j) = abco2_csurf(i,j) * &
+                              (dissi14cabio_field(i,j,1,tau)/(dissicabio_field(i,j,1,tau) + epsln))
+          ab14co2_alpha(i,j) = abco2_alpha(i,j) * (1.0 + delta_14catm(i,j) * 1.0e-03)
+       enddo; enddo ; !} i, j
 
        call g_tracer_set_values(tracer_list,'ab_htotal' ,'field',htotal_field,isd,jsd,ntau=1)
-       call g_tracer_set_values(tracer_list,'ab_htotal14c','field',htotal14c_field,isd,jsd,ntau=1)
        call g_tracer_set_values(tracer_list,'dissicabio','alpha',abco2_alpha    ,isd,jsd)
        call g_tracer_set_values(tracer_list,'dissicabio','csurf',abco2_csurf    ,isd,jsd)
        call g_tracer_set_values(tracer_list,'dissi14cabio','alpha',ab14co2_alpha    ,isd,jsd)

--- a/generic_tracers/generic_blres.F90
+++ b/generic_tracers/generic_blres.F90
@@ -17,7 +17,7 @@
 !
 !----------------------------------------------------------------
 
-module generic_mlres
+module generic_blres
 
   use coupler_types_mod, only: coupler_2d_bc_type
   use field_manager_mod, only: fm_string_len
@@ -36,26 +36,26 @@ module generic_mlres
 
   implicit none ; private
 
-  character(len=fm_string_len), parameter :: mod_name       = 'generic_mlres'
-  character(len=fm_string_len), parameter :: package_name   = 'generic_mlres'
+  character(len=fm_string_len), parameter :: mod_name       = 'generic_blres'
+  character(len=fm_string_len), parameter :: package_name   = 'generic_blres'
 
-  public do_generic_mlres
-  public generic_mlres_register
-  public generic_mlres_init
-  public generic_mlres_update_from_coupler
-  public generic_mlres_update_from_source
-  public generic_mlres_set_boundary_values
-  public generic_mlres_end
+  public do_generic_blres
+  public generic_blres_register
+  public generic_blres_init
+  public generic_blres_update_from_coupler
+  public generic_blres_update_from_source
+  public generic_blres_set_boundary_values
+  public generic_blres_end
 
   !The following logical for using this module is overwritten 
   ! by generic_tracer_nml namelist
-  logical, save :: do_generic_mlres = .false.
+  logical, save :: do_generic_blres = .false.
 
   real, parameter :: epsln=1.0e-30
 
   real :: reset_time=1.0
 
-  namelist /generic_mlres_nml/ reset_time
+  namelist /generic_blres_nml/ reset_time
   !
   !This type contains all the parameters and arrays used in this module.
   !
@@ -64,18 +64,18 @@ module generic_mlres
   !It suffices for varables to be a declared at the top of the module. 
   !nnz: Find out about the timing overhead for using type%x rather than x
 
-  type generic_mlres_params
+  type generic_blres_params
       real :: Rho_0
      character(len=fm_string_len) :: ice_restart_file
      character(len=fm_string_len) :: ocean_restart_file,IC_file
-  end type generic_mlres_params
+  end type generic_blres_params
 
 
-  type(generic_mlres_params) :: param
+  type(generic_blres_params) :: param
 
 contains
 
-  subroutine generic_mlres_register(tracer_list)
+  subroutine generic_blres_register(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
 
 integer                                                 :: ioun
@@ -84,7 +84,7 @@ integer                                                 :: io_status
 character(len=fm_string_len)                            :: name
 integer                                                 :: stdoutunit,stdlogunit
 
-    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_register'
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_register'
 
 ! provide for namelist over-ride
 ! This needs to go before the add_tracers in order to allow the namelist 
@@ -93,26 +93,26 @@ integer                                                 :: stdoutunit,stdlogunit
 stdoutunit=stdout();stdlogunit=stdlog()
 
 #ifdef INTERNAL_FILE_NML
-read (input_nml_file, nml=generic_mlres_nml, iostat=io_status)
-ierr = check_nml_error(io_status,'generic_mlres_nml')
+read (input_nml_file, nml=generic_blres_nml, iostat=io_status)
+ierr = check_nml_error(io_status,'generic_blres_nml')
 #else
 ioun = open_namelist_file()
 read  (ioun, generic_bling_nml,iostat=io_status)
-ierr = check_nml_error(io_status,'generic_mlres_nml')
+ierr = check_nml_error(io_status,'generic_blres_nml')
 call close_file (ioun)
 #endif
 
 write (stdoutunit,'(/)')
-write (stdoutunit, generic_mlres_nml)
-write (stdlogunit, generic_mlres_nml)
+write (stdoutunit, generic_blres_nml)
+write (stdlogunit, generic_blres_nml)
 
     !Specify all prognostic and diagnostic tracers of this modules.
     call user_add_tracers(tracer_list)
     
     
-  end subroutine generic_mlres_register
+  end subroutine generic_blres_register
 
-  ! <SUBROUTINE NAME="generic_mlres_init">
+  ! <SUBROUTINE NAME="generic_blres_init">
   !  <OVERVIEW>
   !   Initialize the generic mixed layer residence tracer
   !  </OVERVIEW>
@@ -123,17 +123,17 @@ write (stdlogunit, generic_mlres_nml)
   !       Allocates all work arrays used in the module. 
   !  </DESCRIPTION>
   !  <TEMPLATE>
-  !   call generic_mlres_init(tracer_list)
+  !   call generic_blres_init(tracer_list)
   !  </TEMPLATE>
   !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
   !   Pointer to the head of generic tracer list.
   !  </IN>
   ! </SUBROUTINE>
 
-  subroutine generic_mlres_init(tracer_list)
+  subroutine generic_blres_init(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
 
-    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_init'
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_init'
 
     !Specify and initialize all parameters used by this package
     call user_add_params
@@ -141,7 +141,7 @@ write (stdlogunit, generic_mlres_nml)
     !Allocate and initiate all the private work arrays used by this module.
     !call user_allocate_arrays 
 
-  end subroutine generic_mlres_init
+  end subroutine generic_blres_init
 
   subroutine user_allocate_arrays
 
@@ -164,7 +164,7 @@ write (stdlogunit, generic_mlres_nml)
     !Specify all parameters used in this modules.
     !==============================================================
     !User adds one call for each parameter below!
-    !User also adds the definition of each parameter in generic_mlres_params type
+    !User also adds the definition of each parameter in generic_blres_params type
     !==============================================================    
 
     !=============
@@ -199,8 +199,8 @@ write (stdlogunit, generic_mlres_nml)
     character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
 
     call g_tracer_start_param_list(package_name)!nnz: Does this append?
-    call g_tracer_add_param('ice_restart_file'   , param%ice_restart_file   , 'ice_ocmip_mlres.res.nc')
-    call g_tracer_add_param('ocean_restart_file' , param%ocean_restart_file , 'ocmip_mlres.res.nc' )
+    call g_tracer_add_param('ice_restart_file'   , param%ice_restart_file   , 'ice_ocmip_blres.res.nc')
+    call g_tracer_add_param('ocean_restart_file' , param%ocean_restart_file , 'ocmip_blres.res.nc' )
     call g_tracer_add_param('IC_file'       , param%IC_file       , '')
     call g_tracer_end_param_list(package_name)
 
@@ -216,19 +216,19 @@ write (stdlogunit, generic_mlres_nml)
     !and provide the corresponding parameters array
     !methods: flux_gas,flux_runoff,flux_wetdep,flux_drydep  
     !
-    !prog_tracers: mlres
+    !prog_tracers: blres
     !diag_tracers: none
     !
     !age
     call g_tracer_add(tracer_list,package_name,               &
-         name          = 'mlres',                             &
+         name          = 'blres',                             &
          longname      = 'residence time inside mixed layer', &
          units         = 'years',                             &
          init_value    = 0.0,                                 &
          prog          = .true.)
 
     call g_tracer_add(tracer_list,package_name,                &
-         name          = 'mlres_inv',                          &
+         name          = 'blres_inv',                          &
          longname      = 'residence time outside mixed layer', &
          units         = 'years',                              &
          init_value    = 0.0,                                  &
@@ -237,7 +237,7 @@ write (stdlogunit, generic_mlres_nml)
 
   end subroutine user_add_tracers
 
-  ! <SUBROUTINE NAME="generic_mlres_update_from_coupler">
+  ! <SUBROUTINE NAME="generic_blres_update_from_coupler">
   !  <OVERVIEW>
   !   Modify the values obtained from the coupler if necessary.
   !  </OVERVIEW>
@@ -247,22 +247,22 @@ write (stdlogunit, generic_mlres_nml)
   !   This subroutine is the place for specific tracer manipulations.
   !  </DESCRIPTION>
   !  <TEMPLATE>
-  !   call generic_mlres_update_from_coupler(tracer_list) 
+  !   call generic_blres_update_from_coupler(tracer_list) 
   !  </TEMPLATE>
   !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
   !   Pointer to the head of generic tracer list.
   !  </IN>
   ! </SUBROUTINE>
-  subroutine generic_mlres_update_from_coupler(tracer_list)
+  subroutine generic_blres_update_from_coupler(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
-    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_update_from_coupler'
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_update_from_coupler'
     !
     !Nothing specific to be done for mixed layer residence tracers
     !
     return
-  end subroutine generic_mlres_update_from_coupler
+  end subroutine generic_blres_update_from_coupler
 
-  ! <SUBROUTINE NAME="generic_mlres_update_from_source">
+  ! <SUBROUTINE NAME="generic_blres_update_from_source">
   !  <OVERVIEW>
   !   Update tracer concentration fields due to the source/sink contributions.
   !  </OVERVIEW>
@@ -270,7 +270,7 @@ write (stdlogunit, generic_mlres_nml)
   !   Sets age to zero in uppermost level and increments it by the time step elsewhere
   !  </DESCRIPTION>
   ! </SUBROUTINE>
-  subroutine generic_mlres_update_from_source( tracer_list,tau,dt,       &
+  subroutine generic_blres_update_from_source( tracer_list,tau,dt,       &
                                                hblt_depth,dzt,ilb,jlb  )
 
     type(g_tracer_type),            pointer    :: tracer_list
@@ -279,11 +279,11 @@ write (stdlogunit, generic_mlres_nml)
     real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth
     real, dimension(ilb:,jlb:,:),   intent(in) :: dzt
 
-    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_update_from_source'
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_update_from_source'
     integer                                 :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,i,j,k
     real, parameter                         :: secs_in_year_r = 1.0 / (86400.0 * 365.25)
     real, dimension(:,:,:)  , pointer       :: grid_tmask
-    real, dimension(:,:,:,:), pointer       :: p_mlres_field, p_mlres_inv_field
+    real, dimension(:,:,:,:), pointer       :: p_blres_field, p_blres_inv_field
 
     real, dimension(:,:,:), allocatable :: zt
 
@@ -291,8 +291,8 @@ write (stdlogunit, generic_mlres_nml)
 
     allocate( zt(isd:ied,jsd:jed,nk) ); zt=0.0
 
-    call g_tracer_get_pointer(tracer_list, 'mlres'    , 'field', p_mlres_field    )
-    call g_tracer_get_pointer(tracer_list, 'mlres_inv', 'field', p_mlres_inv_field)
+    call g_tracer_get_pointer(tracer_list, 'blres'    , 'field', p_blres_field    )
+    call g_tracer_get_pointer(tracer_list, 'blres_inv', 'field', p_blres_inv_field)
 
     ! Compute depth of the bottom of the cell
     zt = 0.0
@@ -306,16 +306,16 @@ write (stdlogunit, generic_mlres_nml)
     do k = 1, nk; do j = jsc, jec ; do i = isc, iec
 
       if (zt(i,j,k) .le. hblt_depth(i,j) ) then
-        !if ( p_mlres_inv_field(i,j,k,tau) .gt. 1 ) then
-        if ( p_mlres_inv_field(i,j,k,tau) .gt. reset_time ) then
+        !if ( p_blres_inv_field(i,j,k,tau) .gt. 1 ) then
+        if ( p_blres_inv_field(i,j,k,tau) .gt. reset_time ) then
           ! Reset tracers
-          p_mlres_field    (i,j,k,tau) = 0.0
-          p_mlres_inv_field(i,j,k,tau) = 0.0
+          p_blres_field    (i,j,k,tau) = 0.0
+          p_blres_inv_field(i,j,k,tau) = 0.0
         else
-          p_mlres_field(i,j,k,tau) = p_mlres_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
+          p_blres_field(i,j,k,tau) = p_blres_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
         endif
       else
-        p_mlres_inv_field(i,j,k,tau) = p_mlres_inv_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
+        p_blres_inv_field(i,j,k,tau) = p_blres_inv_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
       endif
 
     enddo; enddo; enddo !} i,j,k
@@ -323,9 +323,9 @@ write (stdlogunit, generic_mlres_nml)
     deallocate (zt)
 
     return
-  end subroutine generic_mlres_update_from_source
+  end subroutine generic_blres_update_from_source
 
-  ! <SUBROUTINE NAME="generic_mlres_set_boundary_values">
+  ! <SUBROUTINE NAME="generic_blres_set_boundary_values">
   !  <OVERVIEW>
   !   Calculate and set coupler values at the surface / bottom
   !  </OVERVIEW>
@@ -333,7 +333,7 @@ write (stdlogunit, generic_mlres_nml)
   !   
   !  </DESCRIPTION>
   !  <TEMPLATE>
-  !   call generic_mlres_set_boundary_values(tracer_list,SST,SSS,rho,ilb,jlb,tau)
+  !   call generic_blres_set_boundary_values(tracer_list,SST,SSS,rho,ilb,jlb,tau)
   !  </TEMPLATE>
   !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
   !   Pointer to the head of generic tracer list.
@@ -356,7 +356,7 @@ write (stdlogunit, generic_mlres_nml)
   ! </SUBROUTINE>
 
   !User must provide the calculations for these boundary values.
-  subroutine generic_mlres_set_boundary_values(tracer_list,ST,SSS,rho,ilb,jlb,taum1)
+  subroutine generic_blres_set_boundary_values(tracer_list,ST,SSS,rho,ilb,jlb,taum1)
     type(g_tracer_type),          pointer    :: tracer_list
     real, dimension(ilb:,jlb:),     intent(in) :: ST, SSS 
     real, dimension(ilb:,jlb:,:,:), intent(in) :: rho
@@ -365,16 +365,16 @@ write (stdlogunit, generic_mlres_nml)
     integer :: isc,iec, jsc,jec,isd,ied,jsd,jed,nk,ntau , i, j
     real    :: conv_fac,sal,ta,SST,alpha,sc
     real, dimension(:,:,:)  ,pointer  :: grid_tmask
-    real, dimension(:,:,:,:), pointer :: g_mlres_field
-    real, dimension(:,:), ALLOCATABLE :: g_mlres_alpha,g_mlres_csurf
+    real, dimension(:,:,:,:), pointer :: g_blres_field
+    real, dimension(:,:), ALLOCATABLE :: g_blres_alpha,g_blres_csurf
     real, dimension(:,:), ALLOCATABLE :: sc_no
 
-    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_set_boundary_values'
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_set_boundary_values'
 
     return
-  end subroutine generic_mlres_set_boundary_values
+  end subroutine generic_blres_set_boundary_values
 
-  ! <SUBROUTINE NAME="generic_mlres_end">
+  ! <SUBROUTINE NAME="generic_blres_end">
   !  <OVERVIEW>
   !   End the module.
   !  </OVERVIEW>
@@ -382,14 +382,14 @@ write (stdlogunit, generic_mlres_nml)
   !   Deallocate all work arrays
   !  </DESCRIPTION>
   !  <TEMPLATE>
-  !   call generic_mlres_end
+  !   call generic_blres_end
   !  </TEMPLATE>
   ! </SUBROUTINE>
 
-  subroutine generic_mlres_end
-    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_end'
+  subroutine generic_blres_end
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_end'
     !call user_deallocate_arrays
 
-  end subroutine generic_mlres_end
+  end subroutine generic_blres_end
 
-end module generic_mlres
+end module generic_blres

--- a/generic_tracers/generic_mlres.F90
+++ b/generic_tracers/generic_mlres.F90
@@ -1,0 +1,395 @@
+!----------------------------------------------------------------
+! <CONTACT EMAIL="Niki.Zadeh@noaa.gov"> Niki Zadeh 
+! </CONTACT>
+! 
+! <REVIEWER EMAIL="William.Cooke@noaa.gov"> William Cooke
+! </REVIEWER>
+!<OVERVIEW>
+!</OVERVIEW>
+!
+!<DESCRIPTION>
+!       Implementation of routines to solve the amount of time that a water parcel 
+!       at any give location has last resided in the mixed layer
+!</DESCRIPTION>
+!
+! </DEVELOPER_NOTES>
+! </INFO>
+!
+!----------------------------------------------------------------
+
+module generic_mlres
+
+  use coupler_types_mod, only: coupler_2d_bc_type
+  use field_manager_mod, only: fm_string_len
+  !use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
+  use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum
+  use fms_mod,           only: write_version_number, open_namelist_file, check_nml_error, close_file
+  use time_manager_mod, only : time_type
+  use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
+
+  use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list
+  use g_tracer_utils, only : g_tracer_add,g_tracer_add_param, g_tracer_set_files
+  use g_tracer_utils, only : g_tracer_set_values,g_tracer_get_pointer,g_tracer_get_common
+  use g_tracer_utils, only : g_tracer_coupler_set,g_tracer_coupler_get
+  use g_tracer_utils, only : g_tracer_send_diag, g_tracer_get_values  
+
+
+  implicit none ; private
+
+  character(len=fm_string_len), parameter :: mod_name       = 'generic_mlres'
+  character(len=fm_string_len), parameter :: package_name   = 'generic_mlres'
+
+  public do_generic_mlres
+  public generic_mlres_register
+  public generic_mlres_init
+  public generic_mlres_update_from_coupler
+  public generic_mlres_update_from_source
+  public generic_mlres_set_boundary_values
+  public generic_mlres_end
+
+  !The following logical for using this module is overwritten 
+  ! by generic_tracer_nml namelist
+  logical, save :: do_generic_mlres = .false.
+
+  real, parameter :: epsln=1.0e-30
+
+  real :: reset_time=1.0
+
+  namelist /generic_mlres_nml/ reset_time
+  !
+  !This type contains all the parameters and arrays used in this module.
+  !
+  !Note that there is no programatic reason for treating
+  !the following as a type. These are the parameters used only in this module. 
+  !It suffices for varables to be a declared at the top of the module. 
+  !nnz: Find out about the timing overhead for using type%x rather than x
+
+  type generic_mlres_params
+      real :: Rho_0
+     character(len=fm_string_len) :: ice_restart_file
+     character(len=fm_string_len) :: ocean_restart_file,IC_file
+  end type generic_mlres_params
+
+
+  type(generic_mlres_params) :: param
+
+contains
+
+  subroutine generic_mlres_register(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+
+integer                                                 :: ioun
+integer                                                 :: ierr
+integer                                                 :: io_status
+character(len=fm_string_len)                            :: name
+integer                                                 :: stdoutunit,stdlogunit
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_register'
+
+! provide for namelist over-ride
+! This needs to go before the add_tracers in order to allow the namelist 
+! settings to switch tracers on and off.
+!
+stdoutunit=stdout();stdlogunit=stdlog()
+
+#ifdef INTERNAL_FILE_NML
+read (input_nml_file, nml=generic_mlres_nml, iostat=io_status)
+ierr = check_nml_error(io_status,'generic_mlres_nml')
+#else
+ioun = open_namelist_file()
+read  (ioun, generic_bling_nml,iostat=io_status)
+ierr = check_nml_error(io_status,'generic_mlres_nml')
+call close_file (ioun)
+#endif
+
+write (stdoutunit,'(/)')
+write (stdoutunit, generic_mlres_nml)
+write (stdlogunit, generic_mlres_nml)
+
+    !Specify all prognostic and diagnostic tracers of this modules.
+    call user_add_tracers(tracer_list)
+    
+    
+  end subroutine generic_mlres_register
+
+  ! <SUBROUTINE NAME="generic_mlres_init">
+  !  <OVERVIEW>
+  !   Initialize the generic mixed layer residence tracer
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   This subroutine: 
+  !       Adds all the residence tracers to the list of generic Tracers passed to it via utility subroutine g_tracer_add().
+  !       Adds all the parameters used by this module via utility subroutine g_tracer_add_param().
+  !       Allocates all work arrays used in the module. 
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_mlres_init(tracer_list)
+  !  </TEMPLATE>
+  !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
+  !   Pointer to the head of generic tracer list.
+  !  </IN>
+  ! </SUBROUTINE>
+
+  subroutine generic_mlres_init(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_init'
+
+    !Specify and initialize all parameters used by this package
+    call user_add_params
+
+    !Allocate and initiate all the private work arrays used by this module.
+    !call user_allocate_arrays 
+
+  end subroutine generic_mlres_init
+
+  subroutine user_allocate_arrays
+
+    ! Nothing to do for mixed layer tracer
+    ! call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau) 
+
+  end subroutine user_allocate_arrays
+
+  subroutine user_deallocate_arrays
+  !   This is an internal sub, not a public interface.
+  !   Deallocate all the work arrays allocated by user_allocate_arrays.
+  !
+  end subroutine user_deallocate_arrays
+  !
+  !   This is an internal sub, not a public interface.
+  !   Add all the parameters to be used in this module. 
+  !
+  subroutine user_add_params
+
+    !Specify all parameters used in this modules.
+    !==============================================================
+    !User adds one call for each parameter below!
+    !User also adds the definition of each parameter in generic_mlres_params type
+    !==============================================================    
+
+    !=============
+    !Block Starts: g_tracer_add_param
+    !=============
+    !Add the known experimental parameters used for calculations
+    !in this module.
+    !All the g_tracer_add_param calls must happen between 
+    !g_tracer_start_param_list and g_tracer_end_param_list  calls.
+    !This implementation enables runtime overwrite via field_table.
+
+    call g_tracer_start_param_list(package_name)
+    !  Rho_0 is used in the Boussinesq
+    !  approximation to calculations of pressure and
+    !  pressure gradients, in units of kg m-3.
+    call g_tracer_add_param('RHO_0', param%Rho_0, 1035.0)
+
+    call g_tracer_end_param_list(package_name)
+    !===========
+    !Block Ends: g_tracer_add_param
+    !===========
+
+  end subroutine user_add_params
+
+  !
+  !   This is an internal sub, not a public interface.
+  !   Add all the tracers to be used in this module. 
+  !
+  subroutine user_add_tracers(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+
+    character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+
+    call g_tracer_start_param_list(package_name)!nnz: Does this append?
+    call g_tracer_add_param('ice_restart_file'   , param%ice_restart_file   , 'ice_ocmip_mlres.res.nc')
+    call g_tracer_add_param('ocean_restart_file' , param%ocean_restart_file , 'ocmip_mlres.res.nc' )
+    call g_tracer_add_param('IC_file'       , param%IC_file       , '')
+    call g_tracer_end_param_list(package_name)
+
+    ! Set Restart files
+    call g_tracer_set_files(ice_restart_file=param%ice_restart_file, ocean_restart_file=param%ocean_restart_file )
+
+    !=====================================================
+    !Specify all prognostic tracers of this modules.
+    !=====================================================
+    !User adds one call for each prognostic tracer below!
+    !User should specify if fluxes must be extracted from boundary 
+    !by passing one or more of the following methods as .true.  
+    !and provide the corresponding parameters array
+    !methods: flux_gas,flux_runoff,flux_wetdep,flux_drydep  
+    !
+    !prog_tracers: mlres
+    !diag_tracers: none
+    !
+    !age
+    call g_tracer_add(tracer_list,package_name,               &
+         name          = 'mlres',                             &
+         longname      = 'residence time inside mixed layer', &
+         units         = 'years',                             &
+         init_value    = 0.0,                                 &
+         prog          = .true.)
+
+    call g_tracer_add(tracer_list,package_name,                &
+         name          = 'mlres_inv',                          &
+         longname      = 'residence time outside mixed layer', &
+         units         = 'years',                              &
+         init_value    = 0.0,                                  &
+         prog          = .true.)
+
+
+  end subroutine user_add_tracers
+
+  ! <SUBROUTINE NAME="generic_mlres_update_from_coupler">
+  !  <OVERVIEW>
+  !   Modify the values obtained from the coupler if necessary.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Currently an empty stub for ages.
+  !   Some tracer fields need to be modified after values are obtained from the coupler.
+  !   This subroutine is the place for specific tracer manipulations.
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_mlres_update_from_coupler(tracer_list) 
+  !  </TEMPLATE>
+  !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
+  !   Pointer to the head of generic tracer list.
+  !  </IN>
+  ! </SUBROUTINE>
+  subroutine generic_mlres_update_from_coupler(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_update_from_coupler'
+    !
+    !Nothing specific to be done for mixed layer residence tracers
+    !
+    return
+  end subroutine generic_mlres_update_from_coupler
+
+  ! <SUBROUTINE NAME="generic_mlres_update_from_source">
+  !  <OVERVIEW>
+  !   Update tracer concentration fields due to the source/sink contributions.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Sets age to zero in uppermost level and increments it by the time step elsewhere
+  !  </DESCRIPTION>
+  ! </SUBROUTINE>
+  subroutine generic_mlres_update_from_source( tracer_list,tau,dt,       &
+                                               hblt_depth,dzt,ilb,jlb  )
+
+    type(g_tracer_type),            pointer    :: tracer_list
+    integer,                        intent(in) :: tau, ilb, jlb
+    real,                           intent(in) :: dt
+    real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth
+    real, dimension(ilb:,jlb:,:),   intent(in) :: dzt
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_update_from_source'
+    integer                                 :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,i,j,k
+    real, parameter                         :: secs_in_year_r = 1.0 / (86400.0 * 365.25)
+    real, dimension(:,:,:)  , pointer       :: grid_tmask
+    real, dimension(:,:,:,:), pointer       :: p_mlres_field, p_mlres_inv_field
+
+    real, dimension(:,:,:), allocatable :: zt
+
+    call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,grid_tmask=grid_tmask)
+
+    allocate( zt(isd:ied,jsd:jed,nk) ); zt=0.0
+
+    call g_tracer_get_pointer(tracer_list, 'mlres'    , 'field', p_mlres_field    )
+    call g_tracer_get_pointer(tracer_list, 'mlres_inv', 'field', p_mlres_inv_field)
+
+    ! Compute depth of the bottom of the cell
+    zt = 0.0
+    do j = jsc, jec ; do i = isc, iec   !{
+       zt(i,j,1) = dzt(i,j,1)
+    enddo; enddo !} i,j
+    do k = 2, nk ; do j = jsc, jec ; do i = isc, iec   !{
+       zt(i,j,k) = zt(i,j,k-1) + dzt(i,j,k)
+    enddo; enddo; enddo !} i,j
+
+    do k = 1, nk; do j = jsc, jec ; do i = isc, iec
+
+      if (zt(i,j,k) .le. hblt_depth(i,j) ) then
+        !if ( p_mlres_inv_field(i,j,k,tau) .gt. 1 ) then
+        if ( p_mlres_inv_field(i,j,k,tau) .gt. reset_time ) then
+          ! Reset tracers
+          p_mlres_field    (i,j,k,tau) = 0.0
+          p_mlres_inv_field(i,j,k,tau) = 0.0
+        else
+          p_mlres_field(i,j,k,tau) = p_mlres_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
+        endif
+      else
+        p_mlres_inv_field(i,j,k,tau) = p_mlres_inv_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
+      endif
+
+    enddo; enddo; enddo !} i,j,k
+
+    deallocate (zt)
+
+    return
+  end subroutine generic_mlres_update_from_source
+
+  ! <SUBROUTINE NAME="generic_mlres_set_boundary_values">
+  !  <OVERVIEW>
+  !   Calculate and set coupler values at the surface / bottom
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_mlres_set_boundary_values(tracer_list,SST,SSS,rho,ilb,jlb,tau)
+  !  </TEMPLATE>
+  !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
+  !   Pointer to the head of generic tracer list.
+  !  </IN>
+  !  <IN NAME="ilb,jlb" TYPE="integer">
+  !   Lower bounds of x and y extents of input arrays on data domain
+  !  </IN>
+  !  <IN NAME="SST" TYPE="real, dimension(ilb:,jlb:)">
+  !   Sea Surface Temperature   
+  !  </IN>
+  !  <IN NAME="SSS" TYPE="real, dimension(ilb:,jlb:)">
+  !   Sea Surface Salinity
+  !  </IN>
+  !  <IN NAME="rho" TYPE="real, dimension(ilb:,jlb:,:,:)">
+  !   Ocean density
+  !  </IN>
+  !  <IN NAME="tau" TYPE="integer">
+  !   Time step index of %field
+  !  </IN>
+  ! </SUBROUTINE>
+
+  !User must provide the calculations for these boundary values.
+  subroutine generic_mlres_set_boundary_values(tracer_list,ST,SSS,rho,ilb,jlb,taum1)
+    type(g_tracer_type),          pointer    :: tracer_list
+    real, dimension(ilb:,jlb:),     intent(in) :: ST, SSS 
+    real, dimension(ilb:,jlb:,:,:), intent(in) :: rho
+    integer,                        intent(in) :: ilb,jlb,taum1
+
+    integer :: isc,iec, jsc,jec,isd,ied,jsd,jed,nk,ntau , i, j
+    real    :: conv_fac,sal,ta,SST,alpha,sc
+    real, dimension(:,:,:)  ,pointer  :: grid_tmask
+    real, dimension(:,:,:,:), pointer :: g_mlres_field
+    real, dimension(:,:), ALLOCATABLE :: g_mlres_alpha,g_mlres_csurf
+    real, dimension(:,:), ALLOCATABLE :: sc_no
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_set_boundary_values'
+
+    return
+  end subroutine generic_mlres_set_boundary_values
+
+  ! <SUBROUTINE NAME="generic_mlres_end">
+  !  <OVERVIEW>
+  !   End the module.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Deallocate all work arrays
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_mlres_end
+  !  </TEMPLATE>
+  ! </SUBROUTINE>
+
+  subroutine generic_mlres_end
+    character(len=fm_string_len), parameter :: sub_name = 'generic_mlres_end'
+    !call user_deallocate_arrays
+
+  end subroutine generic_mlres_end
+
+end module generic_mlres

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -56,9 +56,9 @@ module generic_tracer
   use generic_age,    only : generic_age_init, generic_age_update_from_source,generic_age_update_from_coupler
   use generic_age,    only : generic_age_set_boundary_values, generic_age_end, do_generic_age
 
-  use generic_mlres, only : generic_mlres_register
-  use generic_mlres, only : generic_mlres_init, generic_mlres_update_from_source,generic_mlres_update_from_coupler
-  use generic_mlres, only : generic_mlres_set_boundary_values, generic_mlres_end, do_generic_mlres
+  use generic_blres, only : generic_blres_register
+  use generic_blres, only : generic_blres_init, generic_blres_update_from_source,generic_blres_update_from_coupler
+  use generic_blres, only : generic_blres_set_boundary_values, generic_blres_end, do_generic_blres
 
   use generic_argon,    only : generic_argon_register
   use generic_argon,    only : generic_argon_init, generic_argon_update_from_source,generic_argon_update_from_coupler
@@ -136,7 +136,7 @@ module generic_tracer
 
   namelist /generic_tracer_nml/ do_generic_tracer, do_generic_abiotic, do_generic_age, do_generic_argon, do_generic_CFC, &
       do_generic_SF6, do_generic_TOPAZ,do_generic_ERGOM, do_generic_BLING, do_generic_miniBLING, do_generic_COBALT, &
-      force_update_fluxes, do_generic_mlres
+      force_update_fluxes, do_generic_blres
 
 contains
 
@@ -175,8 +175,8 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_age) &
          call generic_age_register(tracer_list)
 
-    if(do_generic_mlres) &
-         call generic_mlres_register(tracer_list)
+    if(do_generic_blres) &
+         call generic_blres_register(tracer_list)
 
     if(do_generic_argon) &
          call generic_argon_register(tracer_list)
@@ -251,7 +251,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !Allocate and initialize all registered generic tracers
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
        g_tracer => tracer_list        
        !Go through the list of tracers 
        do  
@@ -272,8 +272,8 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_age) &
          call generic_age_init(tracer_list)
 
-    if(do_generic_mlres) &
-         call generic_mlres_init(tracer_list)
+    if(do_generic_blres) &
+         call generic_blres_init(tracer_list)
 
     if(do_generic_argon) &
          call generic_argon_init(tracer_list)
@@ -309,7 +309,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !JGJ 2013/05/31  merged COBALT into siena_201303
 
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -371,9 +371,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     call g_tracer_coupler_get(tracer_list,IOB_struc)
 
     !Specific tracers
-    !    if(do_generic_mlres)  call generic_age_update_from_coupler(tracer_list) !Nothing to do for mixed layer tracer
+    !    if(do_generic_blres)  call generic_age_update_from_coupler(tracer_list) !Nothing to do for mixed layer tracer
 
-    !    if(do_generic_age)    call generic_mlres_update_from_coupler(tracer_list) !Nothing to do for age
+    !    if(do_generic_age)    call generic_blres_update_from_coupler(tracer_list) !Nothing to do for age
 
     !    if(do_generic_argon)    call generic_argon_update_from_coupler(tracer_list) !Nothing to do for argon
 
@@ -518,7 +518,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     if(do_generic_age)   call generic_age_update_from_source(tracer_list,tau,dtts)
 
-    if(do_generic_mlres) call generic_mlres_update_from_source(tracer_list,tau,dtts,hblt_depth,dzt,ilb,jlb)
+    if(do_generic_blres) call generic_blres_update_from_source(tracer_list,tau,dtts,hblt_depth,dzt,ilb,jlb)
 
     !    if(do_generic_argon)    call generic_argon_update_from_source(tracer_list) !Nothing to do for argon
 
@@ -580,7 +580,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_bottom'
 
-    !    if(do_generic_mlres)  call generic_mlres_update_from_bottom(tracer_list)!Nothing to do for mixed layer tracer 
+    !    if(do_generic_blres)  call generic_blres_update_from_bottom(tracer_list)!Nothing to do for mixed layer tracer 
 
     !    if(do_generic_age)    call generic_age_update_from_bottom(tracer_list)!Nothing to do for age 
 
@@ -630,7 +630,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !nnz: Should I loop here or inside the sub g_tracer_vertdiff ?    
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -671,7 +671,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !nnz: Should I loop here or inside the sub g_tracer_vertdiff ?    
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_TOPAZ .or. do_generic_ERGOM &
-       .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
+       .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -743,8 +743,8 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_age) &
          call generic_age_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
 
-    if(do_generic_mlres) &
-         call generic_mlres_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
+    if(do_generic_blres) &
+         call generic_blres_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
 
     if(do_generic_argon) &
          call generic_argon_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
@@ -776,7 +776,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !JGJ 2013/05/31  merged COBALT into siena_201303
     !
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-      .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) &
+      .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) &
        call g_tracer_coupler_set(tracer_list,IOB_struc)
 
   end subroutine generic_tracer_coupler_set
@@ -813,7 +813,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_end'
     if(do_generic_abiotic) call generic_abiotic_end
     if(do_generic_age) call generic_age_end
-    if(do_generic_mlres) call generic_mlres_end
+    if(do_generic_blres) call generic_blres_end
     if(do_generic_argon) call generic_argon_end
     if(do_generic_CFC) call generic_CFC_end
     if(do_generic_SF6) call generic_SF6_end

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -136,7 +136,7 @@ module generic_tracer
 
   namelist /generic_tracer_nml/ do_generic_tracer, do_generic_abiotic, do_generic_age, do_generic_argon, do_generic_CFC, &
       do_generic_SF6, do_generic_TOPAZ,do_generic_ERGOM, do_generic_BLING, do_generic_miniBLING, do_generic_COBALT, &
-      force_update_fluxes
+      force_update_fluxes, do_generic_mlres
 
 contains
 

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -50,7 +50,8 @@ module generic_tracer
 
   use generic_abiotic, only : generic_abiotic_register, generic_abiotic_register_diag
   use generic_abiotic, only : generic_abiotic_init, generic_abiotic_update_from_source
-  use generic_abiotic, only : generic_abiotic_set_boundary_values, generic_abiotic_end, do_generic_abiotic
+  use generic_abiotic, only : generic_abiotic_set_boundary_values, generic_abiotic_end, do_generic_abiotic 
+  use generic_abiotic, only : as_param_abiotic
 
   use generic_age,    only : generic_age_register
   use generic_age,    only : generic_age_init, generic_age_update_from_source,generic_age_update_from_coupler
@@ -68,11 +69,13 @@ module generic_tracer
   use generic_CFC,    only : generic_CFC_init, generic_CFC_update_from_source,generic_CFC_update_from_coupler
   use generic_CFC,    only : generic_CFC_set_boundary_values, generic_CFC_end, do_generic_CFC
   use generic_CFC,    only : generic_CFC_register_diag
+  use generic_CFC, only : as_param_cfc
 
   use generic_SF6,    only : generic_SF6_register
   use generic_SF6,    only : generic_SF6_init, generic_SF6_update_from_source,generic_SF6_update_from_coupler
   use generic_SF6,    only : generic_SF6_set_boundary_values, generic_SF6_end, do_generic_SF6
   use generic_SF6,    only : generic_SF6_register_diag
+  use generic_SF6, only : as_param_sf6
 
   use generic_ERGOM, only : generic_ERGOM_register, generic_ERGOM_register_diag
   use generic_ERGOM, only : generic_ERGOM_init, generic_ERGOM_update_from_source,generic_ERGOM_update_from_coupler
@@ -88,6 +91,7 @@ module generic_tracer
   use generic_BLING,  only : generic_BLING_init, generic_BLING_update_from_source,generic_BLING_register_diag
   use generic_BLING,  only : generic_BLING_update_from_bottom,generic_BLING_update_from_coupler
   use generic_BLING,  only : generic_BLING_set_boundary_values, generic_BLING_end, do_generic_BLING
+  use generic_BLING, only : as_param_bling
 
   use generic_miniBLING_mod,  only : generic_miniBLING_init, generic_miniBLING_register
   use generic_miniBLING_mod,  only : generic_miniBLING_update_from_source,generic_miniBLING_register_diag
@@ -99,6 +103,7 @@ module generic_tracer
   use generic_COBALT,  only : generic_COBALT_init, generic_COBALT_update_from_source,generic_COBALT_register_diag
   use generic_COBALT,  only : generic_COBALT_update_from_bottom,generic_COBALT_update_from_coupler
   use generic_COBALT,  only : generic_COBALT_set_boundary_values, generic_COBALT_end, do_generic_COBALT
+  use generic_COBALT, only : as_param_cobalt
 
   implicit none ; private
 
@@ -133,10 +138,11 @@ module generic_tracer
   logical :: do_generic_tracer = .false.
   logical :: generic_tracer_register_called = .false.
   logical :: force_update_fluxes = .false.
+  character(len=10) :: as_param   = 'gfdl_cmip6'     ! Use default Wanninkhoff/OCMIP2 parameters for air-sea gas transfer
 
   namelist /generic_tracer_nml/ do_generic_tracer, do_generic_abiotic, do_generic_age, do_generic_argon, do_generic_CFC, &
       do_generic_SF6, do_generic_TOPAZ,do_generic_ERGOM, do_generic_BLING, do_generic_miniBLING, do_generic_COBALT, &
-      force_update_fluxes, do_generic_blres
+      force_update_fluxes, do_generic_blres, as_param
 
 contains
 
@@ -166,6 +172,15 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     write (stdoutunit,'(/)')
     write (stdoutunit, generic_tracer_nml)
     write (stdlogunit, generic_tracer_nml)
+
+    ! Use Wanninkhoff 2014 parameters for air-sea gas exchange if as_param='W14' in generic_tracer_nml
+    if (as_param == 'gfdl_cmip6') then
+      if (do_generic_abiotic) as_param_abiotic = as_param
+      if (do_generic_CFC)     as_param_cfc     = as_param
+      if (do_generic_SF6)     as_param_sf6     = as_param
+      if (do_generic_BLING)   as_param_bling   = as_param
+      if (do_generic_COBALT)  as_param_cobalt  = as_param
+    endif
 
     call read_mocsy_namelist()
 

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -56,6 +56,10 @@ module generic_tracer
   use generic_age,    only : generic_age_init, generic_age_update_from_source,generic_age_update_from_coupler
   use generic_age,    only : generic_age_set_boundary_values, generic_age_end, do_generic_age
 
+  use generic_mlres, only : generic_mlres_register
+  use generic_mlres, only : generic_mlres_init, generic_mlres_update_from_source,generic_mlres_update_from_coupler
+  use generic_mlres, only : generic_mlres_set_boundary_values, generic_mlres_end, do_generic_mlres
+
   use generic_argon,    only : generic_argon_register
   use generic_argon,    only : generic_argon_init, generic_argon_update_from_source,generic_argon_update_from_coupler
   use generic_argon,    only : generic_argon_set_boundary_values, generic_argon_end, do_generic_argon
@@ -171,6 +175,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_age) &
          call generic_age_register(tracer_list)
 
+    if(do_generic_mlres) &
+         call generic_mlres_register(tracer_list)
+
     if(do_generic_argon) &
          call generic_argon_register(tracer_list)
 
@@ -244,7 +251,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !Allocate and initialize all registered generic tracers
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
        g_tracer => tracer_list        
        !Go through the list of tracers 
        do  
@@ -264,6 +271,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     if(do_generic_age) &
          call generic_age_init(tracer_list)
+
+    if(do_generic_mlres) &
+         call generic_mlres_init(tracer_list)
 
     if(do_generic_argon) &
          call generic_argon_init(tracer_list)
@@ -299,7 +309,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !JGJ 2013/05/31  merged COBALT into siena_201303
 
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -361,7 +371,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     call g_tracer_coupler_get(tracer_list,IOB_struc)
 
     !Specific tracers
-    !    if(do_generic_age)    call generic_age_update_from_coupler(tracer_list) !Nothing to do for age
+    !    if(do_generic_mlres)  call generic_age_update_from_coupler(tracer_list) !Nothing to do for mixed layer tracer
+
+    !    if(do_generic_age)    call generic_mlres_update_from_coupler(tracer_list) !Nothing to do for age
 
     !    if(do_generic_argon)    call generic_argon_update_from_coupler(tracer_list) !Nothing to do for argon
 
@@ -504,8 +516,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_source'
 
+    if(do_generic_age)   call generic_age_update_from_source(tracer_list,tau,dtts)
 
-    if(do_generic_age)  call generic_age_update_from_source(tracer_list,tau,dtts)
+    if(do_generic_mlres) call generic_mlres_update_from_source(tracer_list,tau,dtts,hblt_depth,dzt,ilb,jlb)
 
     !    if(do_generic_argon)    call generic_argon_update_from_source(tracer_list) !Nothing to do for argon
 
@@ -567,6 +580,8 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_bottom'
 
+    !    if(do_generic_mlres)  call generic_mlres_update_from_bottom(tracer_list)!Nothing to do for mixed layer tracer 
+
     !    if(do_generic_age)    call generic_age_update_from_bottom(tracer_list)!Nothing to do for age 
 
     !    if(do_generic_argon)    call generic_argon_update_from_bottom(tracer_list)!Nothing to do for argon 
@@ -615,7 +630,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !nnz: Should I loop here or inside the sub g_tracer_vertdiff ?    
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -656,7 +671,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !nnz: Should I loop here or inside the sub g_tracer_vertdiff ?    
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_TOPAZ .or. do_generic_ERGOM &
-       .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -728,6 +743,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_age) &
          call generic_age_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
 
+    if(do_generic_mlres) &
+         call generic_mlres_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
+
     if(do_generic_argon) &
          call generic_argon_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
 
@@ -758,7 +776,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !JGJ 2013/05/31  merged COBALT into siena_201303
     !
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-      .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) &
+      .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_mlres) &
        call g_tracer_coupler_set(tracer_list,IOB_struc)
 
   end subroutine generic_tracer_coupler_set
@@ -795,6 +813,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_end'
     if(do_generic_abiotic) call generic_abiotic_end
     if(do_generic_age) call generic_age_end
+    if(do_generic_mlres) call generic_mlres_end
     if(do_generic_argon) call generic_argon_end
     if(do_generic_CFC) call generic_CFC_end
     if(do_generic_SF6) call generic_SF6_end

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -373,6 +373,7 @@ module g_tracer_utils
   public :: g_register_diag_field
   public :: g_send_data
   public :: fm_string_len
+  public :: is_root_pe
   ! <INTERFACE NAME="g_tracer_add_param">
   !  <OVERVIEW>
   !   Add a new parameter for the generic tracer package
@@ -3950,5 +3951,13 @@ contains
 
   END FUNCTION g_send_data_3d
 
+ !> This returns .true. if the current PE is the root PE.
+function is_root_pe()
+  ! This returns .true. if the current PE is the root PE.
+  logical :: is_root_pe
+  is_root_pe = .false.
+  if (mpp_pe() == mpp_root_pe()) is_root_pe = .true.
+  return
+end function is_root_pe
 
 end module g_tracer_utils


### PR DESCRIPTION
This PR includes two updates by @mclaret moved over to from NOAA-GFDL's internal Gitlab.  Since the work was intertwined with 13C tracer development (not included here), the code needed to be manually moved over.

The two updates here include:

- Introduction of a boundary layer residence time tracer
- Flexible air-sea exchange coefficients as runtime parameters