### PR TITLE
WIP: Identify tracers and values to be exported to ATM

### DIFF
--- a/generic_tracers/FMS_coupler_util.F90
+++ b/generic_tracers/FMS_coupler_util.F90
@@ -10,6 +10,7 @@ module FMS_coupler_util
 use mpp_mod,           only : mpp_error, FATAL, WARNING
 use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_deltap, ind_kw
 use coupler_types_mod, only : ind_alpha, ind_csurf, ind_sc_no
+use coupler_types_mod, only : ind_export_value_ice
 
 implicit none ; private
 
@@ -43,6 +44,7 @@ subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, ilb
 
   if ((BC_element /= ind_flux) .and. (BC_element /= ind_alpha) .and. &
       (BC_element /= ind_csurf) .and. (BC_element /= ind_sc_no) .and. &
+      (BC_element /= ind_export_value_ice) .and. &
       (BC_element /= ind_deltap) .and. (BC_element /= ind_kw)) then
     call mpp_error(FATAL,"extract_coupler_values: Unrecognized BC_element.")
   endif
@@ -109,6 +111,7 @@ subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, ilb, jlb
 
   if ((BC_element /= ind_flux) .and. (BC_element /= ind_alpha) .and. &
       (BC_element /= ind_csurf) .and. (BC_element /= ind_sc_no) .and. &
+      (BC_element /= ind_export_value_ice) .and. &
       (BC_element /= ind_deltap) .and. (BC_element /= ind_kw)) then
     call mpp_error(FATAL,"extract_coupler_values: Unrecognized BC_element.")
   endif
@@ -124,7 +127,8 @@ subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, ilb, jlb
        "The requested boundary condition element is not associated.")
   if (.not.associated(BC_struc%bc(BC_index)%field(BC_element)%values)) &
     call mpp_error(FATAL,"set_coupler_values: " // &
-       "The requested boundary condition value array is not associated.")
+    "The requested boundary condition value array is not associated for "//&
+    trim(BC_struc%bc(BC_index)%name))
 
   Array_out => BC_struc%bc(BC_index)%field(BC_element)%values
   


### PR DESCRIPTION
- This is part of a scheme to make tracer related values on OCN grid available
on the ATM grid. Specifically exporting COBALT chl concentration to
atmos_tracer_driver.
- For more details see [https://github.com/nikizadehgfdl/FMScoupler/wiki/Export-values-from-OCN-to-ATM](https://github.com/nikizadehgfdl/FMScoupler/wiki/Export-values-from-OCN-to-ATM)

-