### PR TITLE
Obgc tracer reservoir length scale different for each tracer

### DIFF
--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -390,7 +390,14 @@ contains
          standard_name = "mole_concentration_of_cfc11_in_sea_water", &
          diag_field_units = 'mol m-3', &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
-
+    !fake passive tracer
+    call g_tracer_add(tracer_list,package_name,        &
+         name       = 'gtr1',                        &
+         longname   = 'fake passive tracer',          &
+         units      = 'NA',                        &
+         prog       = .true.,                          &
+         requires_src_info  = .false.,                 &
+         flux_gas       = .false.)
 
   end subroutine user_add_tracers
 

--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -391,6 +391,7 @@ contains
          diag_field_units = 'mol m-3', &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
 
+
   end subroutine user_add_tracers
 
   ! <SUBROUTINE NAME="generic_CFC_update_from_coupler">

--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -390,21 +390,6 @@ contains
          standard_name = "mole_concentration_of_cfc11_in_sea_water", &
          diag_field_units = 'mol m-3', &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
-    !fake passive tracers
-    call g_tracer_add(tracer_list,package_name,        &
-         name       = 'gtr1',                        &
-         longname   = 'fake passive tracer1',          &
-         units      = 'NA',                        &
-         prog       = .true.,                          &
-         requires_src_info  = .false.,                 &
-         flux_gas       = .false.)
-    call g_tracer_add(tracer_list,package_name,        &
-         name       = 'gtr2',                        &
-         longname   = 'fake passive tracer2',          &
-         units      = 'NA',                        &
-         prog       = .true.,                          &
-         requires_src_info  = .false.,                 &
-         flux_gas       = .false.)
 
   end subroutine user_add_tracers
 

--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -390,10 +390,17 @@ contains
          standard_name = "mole_concentration_of_cfc11_in_sea_water", &
          diag_field_units = 'mol m-3', &
          diag_field_scaling_factor = 1035.0)   ! rho = 1035.0 kg/m3, converts mol/kg to mol/m3
-    !fake passive tracer
+    !fake passive tracers
     call g_tracer_add(tracer_list,package_name,        &
          name       = 'gtr1',                        &
-         longname   = 'fake passive tracer',          &
+         longname   = 'fake passive tracer1',          &
+         units      = 'NA',                        &
+         prog       = .true.,                          &
+         requires_src_info  = .false.,                 &
+         flux_gas       = .false.)
+    call g_tracer_add(tracer_list,package_name,        &
+         name       = 'gtr2',                        &
+         longname   = 'fake passive tracer2',          &
          units      = 'NA',                        &
          prog       = .true.,                          &
          requires_src_info  = .false.,                 &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -8487,7 +8487,7 @@ write (stdlogunit, generic_COBALT_nml)
                     cobalt%p_nsmz(i,j,k,tau) + cobalt%p_nmdz(i,j,k,tau) + &
                     cobalt%p_nlgz(i,j,k,tau)))*grid_tmask(i,j,k)
         imbal = (post_totc(i,j,k) - pre_totc(i,j,k))*86400.0/dt*1.03e6
-         if (abs(imbal).gt.1.0e-10) then
+         if (abs(imbal).gt.1.0e-9) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Carbon')
          endif

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -9647,7 +9647,7 @@ write (stdlogunit, generic_COBALT_nml)
          model_time, rmask = grid_tmask,&
          is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
     if (cobalt%id_kfe_eq_lig .gt. 0)            &
-         used = g_send_data(cobalt%id_kfe_eq_lig, log10(cobalt%kfe_eq_lig),         &
+         used = g_send_data(cobalt%id_kfe_eq_lig, log10(cobalt%kfe_eq_lig+epsln),         &
          model_time, rmask = grid_tmask,&
          is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
     if (cobalt%id_feprime .gt. 0)            &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -8487,7 +8487,7 @@ write (stdlogunit, generic_COBALT_nml)
                     cobalt%p_nsmz(i,j,k,tau) + cobalt%p_nmdz(i,j,k,tau) + &
                     cobalt%p_nlgz(i,j,k,tau)))*grid_tmask(i,j,k)
         imbal = (post_totc(i,j,k) - pre_totc(i,j,k))*86400.0/dt*1.03e6
-         if (abs(imbal).gt.1.0e-9) then
+         if (abs(imbal).gt.1.0e-10) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Carbon')
          endif

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -267,6 +267,7 @@ module g_tracer_utils
      logical :: requires_restart = .true.
      ! Tracer source: filename, type, var name, units, record, gridfile  
      character(len=fm_string_len) :: src_file, src_var_name, src_var_unit, src_var_gridspec
+     character(len=fm_string_len) :: obc_src_file_name,obc_src_field_name
      integer :: src_var_record
      logical :: requires_src_info = .false.
      real    :: src_var_unit_conversion = 1.0 !This factor depends on the tracer. Ask  Jasmin
@@ -372,6 +373,7 @@ module g_tracer_utils
   public :: g_tracer_get_src_info
   public :: g_register_diag_field
   public :: g_send_data
+  public :: g_tracer_get_obc_segment_props
   ! <INTERFACE NAME="g_tracer_add_param">
   !  <OVERVIEW>
   !   Add a new parameter for the generic tracer package
@@ -936,6 +938,8 @@ contains
     call  g_tracer_add_param(trim(g_tracer%name)//"_valid_min",        g_tracer%src_var_valid_min , -99.0) 
     call  g_tracer_add_param(trim(g_tracer%name)//"_valid_max",        g_tracer%src_var_valid_max , +1.0e64) 
     call  g_tracer_add_param(trim(g_tracer%name)//"_requires_restart", g_tracer%requires_restart , .true.) 
+    call  g_tracer_add_param(trim(g_tracer%name)//"_obc_src_file_name",g_tracer%obc_src_file_name ,  'obgc_obc.nc') 
+    call  g_tracer_add_param(trim(g_tracer%name)//"_obc_src_field_name",g_tracer%obc_src_field_name,trim(g_tracer%name)) 
     
     !===================================================================
     !Reversed Linked List implementation! Make this new node to be the head of the list.
@@ -3741,6 +3745,25 @@ contains
     src_var_valid_max = g_tracer%src_var_valid_max
 
   end subroutine g_tracer_get_src_info
+
+  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, src_file, src_var_name)
+    type(g_tracer_type),      pointer    :: g_tracer_list,g_tracer
+    character(len=*),         intent(in) :: name
+    character(len=*),         intent(out):: src_file, src_var_name
+    character(len=fm_string_len), parameter :: sub_name = 'g_tracer_get_obc_segment_props'
+
+    if(.NOT. associated(g_tracer_list)) call mpp_error(FATAL, trim(sub_name)//&
+         ": No tracer in the list.")
+
+    g_tracer => g_tracer_list !Local pointer. Do not change the input pointer!
+    !Find the node which has name=name
+    call g_tracer_find(g_tracer,name)
+    if(.NOT. associated(g_tracer)) call mpp_error(FATAL, trim(sub_name)//&
+         ": No tracer in the list with name="//trim(name))
+
+    src_file = g_tracer%obc_src_file_name
+    src_var_name = g_tracer%obc_src_field_name
+  end subroutine g_tracer_get_obc_segment_props
 
   function g_register_diag_field(module_name, field_name, axes, init_time,         &
        long_name, units, missing_value, range, mask_variant, standard_name,      &

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -268,6 +268,8 @@ module g_tracer_utils
      ! Tracer source: filename, type, var name, units, record, gridfile  
      character(len=fm_string_len) :: src_file, src_var_name, src_var_unit, src_var_gridspec
      character(len=fm_string_len) :: obc_src_file_name,obc_src_field_name
+     real    :: obc_lfac_in = 1. 
+     real    :: obc_lfac_out= 1.
      logical :: obc_has = .true.
      integer :: src_var_record
      logical :: requires_src_info = .false.
@@ -942,6 +944,8 @@ contains
     call  g_tracer_add_param(trim(g_tracer%name)//"_obc_has",g_tracer%obc_has , .true.) 
     call  g_tracer_add_param(trim(g_tracer%name)//"_obc_src_file_name",g_tracer%obc_src_file_name ,  'obgc_obc.nc') 
     call  g_tracer_add_param(trim(g_tracer%name)//"_obc_src_field_name",g_tracer%obc_src_field_name,trim(g_tracer%name)) 
+    call  g_tracer_add_param(trim(g_tracer%name)//"_obc_lfac_in" ,g_tracer%obc_lfac_in , 1.0) 
+    call  g_tracer_add_param(trim(g_tracer%name)//"_obc_lfac_out",g_tracer%obc_lfac_out, 1.0) 
     
     !===================================================================
     !Reversed Linked List implementation! Make this new node to be the head of the list.
@@ -2004,7 +2008,7 @@ contains
     character(len=*),         intent(in) :: name
     character(len=*),         intent(in) :: member
     type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer 
-    character(len=fm_string_len), intent(out) :: string
+    character(len=*), intent(out) :: string
     character(len=fm_string_len), parameter :: sub_name = 'g_tracer_get_string'
 
     if(.NOT. associated(g_tracer_list)) call mpp_error(FATAL, trim(sub_name)//&
@@ -3748,11 +3752,12 @@ contains
 
   end subroutine g_tracer_get_src_info
 
-  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name)
+  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name,lfac_in,lfac_out)
     type(g_tracer_type),      pointer    :: g_tracer_list,g_tracer
     character(len=*),         intent(in) :: name
     logical,                  intent(out):: obc_has                !<.true. if This tracer has OBC  
     character(len=*),optional,intent(out):: src_file, src_var_name !<OBC source file and variable in file
+    real,            optional,intent(out):: lfac_in,lfac_out       !<OBC reservoir inverse lengthscale factor    
     character(len=fm_string_len), parameter :: sub_name = 'g_tracer_get_obc_segment_props'
 
     if(.NOT. associated(g_tracer_list)) call mpp_error(FATAL, trim(sub_name)//&
@@ -3764,9 +3769,11 @@ contains
     if(.NOT. associated(g_tracer)) call mpp_error(FATAL, trim(sub_name)//&
          ": No tracer in the list with name="//trim(name))
 
-    src_file = g_tracer%obc_src_file_name
-    src_var_name = g_tracer%obc_src_field_name
     obc_has = g_tracer%obc_has
+    if(present(src_file))     src_file = g_tracer%obc_src_file_name
+    if(present(src_var_name)) src_var_name = g_tracer%obc_src_field_name
+    if(present(lfac_in))      lfac_in  = g_tracer%obc_lfac_in
+    if(present(lfac_out))     lfac_out = g_tracer%obc_lfac_out
   end subroutine g_tracer_get_obc_segment_props
 
   function g_register_diag_field(module_name, field_name, axes, init_time,         &

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -268,6 +268,7 @@ module g_tracer_utils
      ! Tracer source: filename, type, var name, units, record, gridfile  
      character(len=fm_string_len) :: src_file, src_var_name, src_var_unit, src_var_gridspec
      character(len=fm_string_len) :: obc_src_file_name,obc_src_field_name
+     logical :: obc_has = .true.
      integer :: src_var_record
      logical :: requires_src_info = .false.
      real    :: src_var_unit_conversion = 1.0 !This factor depends on the tracer. Ask  Jasmin
@@ -938,6 +939,7 @@ contains
     call  g_tracer_add_param(trim(g_tracer%name)//"_valid_min",        g_tracer%src_var_valid_min , -99.0) 
     call  g_tracer_add_param(trim(g_tracer%name)//"_valid_max",        g_tracer%src_var_valid_max , +1.0e64) 
     call  g_tracer_add_param(trim(g_tracer%name)//"_requires_restart", g_tracer%requires_restart , .true.) 
+    call  g_tracer_add_param(trim(g_tracer%name)//"_obc_has",g_tracer%obc_has , .true.) 
     call  g_tracer_add_param(trim(g_tracer%name)//"_obc_src_file_name",g_tracer%obc_src_file_name ,  'obgc_obc.nc') 
     call  g_tracer_add_param(trim(g_tracer%name)//"_obc_src_field_name",g_tracer%obc_src_field_name,trim(g_tracer%name)) 
     
@@ -3746,10 +3748,11 @@ contains
 
   end subroutine g_tracer_get_src_info
 
-  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, src_file, src_var_name)
+  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name)
     type(g_tracer_type),      pointer    :: g_tracer_list,g_tracer
     character(len=*),         intent(in) :: name
-    character(len=*),         intent(out):: src_file, src_var_name
+    logical,                  intent(out):: obc_has                !<.true. if This tracer has OBC  
+    character(len=*),optional,intent(out):: src_file, src_var_name !<OBC source file and variable in file
     character(len=fm_string_len), parameter :: sub_name = 'g_tracer_get_obc_segment_props'
 
     if(.NOT. associated(g_tracer_list)) call mpp_error(FATAL, trim(sub_name)//&
@@ -3763,6 +3766,7 @@ contains
 
     src_file = g_tracer%obc_src_file_name
     src_var_name = g_tracer%obc_src_field_name
+    obc_has = g_tracer%obc_has
   end subroutine g_tracer_get_obc_segment_props
 
   function g_register_diag_field(module_name, field_name, axes, init_time,         &


### PR DESCRIPTION
Allow obgc tracers have different reservoir length scales
    
- This update along with an update to MOM6 brings
        in the capability to set tracer reservoir (inverse) length scales for
        individual obgc tracers via ocean_bgc field_table mechanism.
- Tracer resevoir inverse length scales are set as before to 1.0/Lscale_in and
        1.0/Lscale_out
- Users should be able to specify a multiplicative factor for each obgc
        tracer for each IN or OUT direction in the field_table, e.g.,
        alk_obc_lfac_in  = 0.5
        alk_obc_lfac_out = 0.75
 - The factors are multiplied by the inverse length scales before
        reservoir calculations.
 - The default factors for all tracers are 1.
 - No answer changes unless non-one factors are specified in field_table
    
 - There is also a bugfix to COBALT to allow running in debug mode, log10
        must be epsiloned to avoid log(0)
 - There is a bugfix to generic_tracer_utils to allow running in debug
        mode, intent(out) strings must have len=* otherwise we get a crash in
        debug mode like:
        forrtl: severe (408): fort: (18): Dummy character variable 'STRING' has length 1024 which is greater than actual variable length 200
