### PR TITLE
[WIP] Alkalinity deposition flux

### DIFF
--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -33,7 +33,7 @@ module g_tracer_utils
 
 #ifdef _USE_MOM6_DIAG
     use MOM_diag_mediator, only : register_diag_field_MOM=>register_diag_field
-    use MOM_diag_mediator, only : post_data_MOM=>post_data, post_data_1d_k
+    use MOM_diag_mediator, only : post_data_MOM=>post_data
     use MOM_diag_mediator, only : g_diag_ctrl=>diag_ctrl
 #else
     use diag_manager_mod, only : register_diag_field_FMS=>register_diag_field
@@ -3885,7 +3885,7 @@ contains
     else
        call g_tracer_get_diagCS(diag_CS_ptr)
     endif
-    call post_data_1d_k(diag_field_id, field, diag_CS_ptr)     
+    call post_data_MOM(diag_field_id, field, diag_CS_ptr)     
     g_send_data_1d = .TRUE.
 #else
     g_send_data_1d = send_data_FMS(diag_field_id, field, time, is_in, mask, rmask, ie_in, weight, err_msg)
@@ -3913,7 +3913,7 @@ contains
     else
        call g_tracer_get_diagCS(diag_CS_ptr)
     endif
-    call post_data_MOM(diag_field_id, field, diag_CS_ptr)!, mask=rmask)         
+    call post_data_MOM(diag_field_id, field, diag_CS_ptr)
     g_send_data_2d = .TRUE.
 #else
     g_send_data_2d = send_data_FMS(diag_field_id, field, time, is_in, js_in, &
@@ -3942,7 +3942,7 @@ contains
     else
        call g_tracer_get_diagCS(diag_CS_ptr)
     endif
-    call post_data_MOM(diag_field_id, field, diag_CS_ptr)!, mask=rmask) 
+    call post_data_MOM(diag_field_id, field, diag_CS_ptr)
     g_send_data_3d = .TRUE.
 #else
     g_send_data_3d = send_data_FMS(diag_field_id, field, time, is_in, js_in, ks_in, &


### PR DESCRIPTION
- This updates add wet and dry deposition fluxes for tracer alk and
    registers diagnostics for them
- This update by itself should not change anything in the models. It only prepared COBALT to receive the alk fluxes  when the ATM alkalinity fluxes are ready and sent down.  
- atmos_phys repo branch alkalinity_deposition_flux  atmos_dust.F90
      prepares these fluxes on the ATM side to be received by alk.
- Currently these fluxes are set to 0 till the alkalinity content of
      dust fluxes is formulated in line 956 of [atmos_dust.F90](https://gitlab.gfdl.noaa.gov/fms/atmos_phys/-/commit/7c086a6ab789ffec667b58ce220be1668348bb2f#dd6d8ddd1fbd48f1254dda4c25d144c8d2181242_919_956)

- John Dunne wrote:
      "I have been talking with Charlie and Jasmin about running some ESM4.2
    simulations where we add purposefully add alkalinity to the ocean induce
    Carbon Dioxide Removal from the atmosphere, and we think the most
    code-efficient way to do it would be to add connectivity thought the
    coupler like we do for NO3 and Fe.  Would you be able to help me with
    this?  The default would be to assign a zero flux over the ocean, and
    the data override would be to assign a map of wet or dry deposition as
    an alkalinity flux.  Jasmin and I discussed an alternative of creating a
    3D data override flux within the COBALT code, but upon further thought I
    believe that approach would both be much more work and less applicable
    to the long term goal of being able to simulate potential alkalinization
    of the atmosphere (which I think will also be proposed soon)."

- There is also an unrelated  minor change in generic_tracer_utils to allow using newer versions of MOM6 