### PR TITLE
Mom6 update post1dk

### DIFF
--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -33,7 +33,7 @@ module g_tracer_utils
 
 #ifdef _USE_MOM6_DIAG
     use MOM_diag_mediator, only : register_diag_field_MOM=>register_diag_field
-    use MOM_diag_mediator, only : post_data_MOM=>post_data, post_data_1d_k
+    use MOM_diag_mediator, only : post_data_MOM=>post_data
     use MOM_diag_mediator, only : g_diag_ctrl=>diag_ctrl
 #else
     use diag_manager_mod, only : register_diag_field_FMS=>register_diag_field
@@ -3885,7 +3885,7 @@ contains
     else
        call g_tracer_get_diagCS(diag_CS_ptr)
     endif
-    call post_data_1d_k(diag_field_id, field, diag_CS_ptr)     
+    call post_data_MOM(diag_field_id, field, diag_CS_ptr)     
     g_send_data_1d = .TRUE.
 #else
     g_send_data_1d = send_data_FMS(diag_field_id, field, time, is_in, mask, rmask, ie_in, weight, err_msg)


### PR DESCRIPTION
Update required to work with newer MOM6 versions after January 2022
The interface post_data_1dk is remove from MOM6 versions after January 2022