### PR TITLE
Update dev4.2 with changes in FMS

### DIFF
--- a/generic_tracers/FMS_ocmip2_co2calc.F90
+++ b/generic_tracers/FMS_ocmip2_co2calc.F90
@@ -40,7 +40,7 @@ module FMS_ocmip2_co2calc_mod  !{
 !
 
 use fm_util_mod, only: fm_util_start_namelist, fm_util_end_namelist
-use fms_mod,     only: open_namelist_file, check_nml_error, close_file
+use fms_mod,     only: check_nml_error
 use mpp_mod,     only: input_nml_file, mpp_error, stdout, stdlog, WARNING, FATAL
 use mocsy_vars,  only: vars
 
@@ -98,16 +98,9 @@ subroutine read_mocsy_namelist()
     integer :: ioun, ierr, io_status, stdoutunit, stdlogunit
     stdoutunit=stdout();stdlogunit=stdlog()
 
-#ifdef INTERNAL_FILE_NML
     read (input_nml_file, nml=mocsy_nml, iostat=io_status)
     ierr = check_nml_error(io_status,'mocsy_nml')
-#else
-    ioun = open_namelist_file()
-    read  (ioun, mocsy_nml,iostat=io_status)
-    ierr = check_nml_error(io_status,'mocsy_nml')
-    call close_file (ioun)
-#endif
-    
+
     write (stdoutunit,'(/)')
     write (stdoutunit, mocsy_nml)
     write (stdlogunit, mocsy_nml)

--- a/generic_tracers/generic_BLING.F90
+++ b/generic_tracers/generic_BLING.F90
@@ -172,8 +172,7 @@ module generic_BLING
   use coupler_types_mod, only: coupler_2d_bc_type
   use field_manager_mod, only: fm_string_len, fm_path_name_len
   use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum
-  use fms_mod,           only: write_version_number, open_namelist_file, check_nml_error, close_file
-  use fms_mod,           only: field_exist, file_exist
+  use fms_mod,           only: write_version_number, check_nml_error
   use time_manager_mod,  only: time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
   use constants_mod,     only: WTMCO2, WTMO2
@@ -776,15 +775,8 @@ character(len=256), parameter   :: note_header =                                
 !
 stdoutunit=stdout();stdlogunit=stdlog()
 
-#ifdef INTERNAL_FILE_NML
 read (input_nml_file, nml=generic_bling_nml, iostat=io_status)
 ierr = check_nml_error(io_status,'generic_bling_nml')
-#else
-ioun = open_namelist_file()
-read  (ioun, generic_bling_nml,iostat=io_status)
-ierr = check_nml_error(io_status,'generic_bling_nml')
-call close_file (ioun)
-#endif
 
 write (stdoutunit,'(/)')
 write (stdoutunit, generic_bling_nml)

--- a/generic_tracers/generic_BLING.F90
+++ b/generic_tracers/generic_BLING.F90
@@ -177,6 +177,8 @@ module generic_BLING
   use time_manager_mod,  only: time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
   use constants_mod,     only: WTMCO2, WTMO2
+  use fms_mod,           only: stdout, stdlog,mpp_pe,mpp_root_pe
+  use data_override_mod, only: data_override
 
   use g_tracer_utils, only : g_diag_type,g_tracer_type
   use g_tracer_utils, only : g_tracer_start_param_list,g_tracer_end_param_list
@@ -186,7 +188,7 @@ module generic_BLING
   use g_tracer_utils, only : g_tracer_coupler_set,g_tracer_coupler_get
   use g_tracer_utils, only : g_tracer_send_diag, g_tracer_get_values  
   use g_tracer_utils, only : register_diag_field=>g_register_diag_field
-  use g_tracer_utils, only : g_send_data
+  use g_tracer_utils, only : g_send_data, is_root_pe
 
   use FMS_ocmip2_co2calc_mod, only : FMS_ocmip2_co2calc, CO2_dope_vector
 
@@ -207,10 +209,12 @@ module generic_BLING
   public generic_BLING_update_from_bottom
   public generic_BLING_set_boundary_values
   public generic_BLING_end
+  public as_param_bling
 
-  !The following logical for using this module is overwritten 
-  ! generic_tracer_nml namelist
+  !The following variables for using this module 
+  ! are overwritten by generic_tracer_nml namelist
   logical, save :: do_generic_BLING = .false.
+  character(len=10), save :: as_param_bling = 'gfdl_cmip6'
 
   real, parameter :: sperd = 24.0 * 3600.0
   real, parameter :: spery = 365.25 * sperd
@@ -309,7 +313,8 @@ namelist /generic_bling_nml/ co2_calc, do_14c, do_carbon, do_carbon_pre, &
 
      real    :: htotal_scale_lo, htotal_scale_hi, htotal_in
      real    :: Rho_0, a_0, a_1, a_2, a_3, a_4, a_5, b_0, b_1, b_2, b_3, c_0
-     real    :: a1_co2, a2_co2, a3_co2, a4_co2, a1_o2, a2_o2, a3_o2, a4_o2
+     real    :: a1_co2, a2_co2, a3_co2, a4_co2, a5_co2 
+     real    :: a1_o2, a2_o2, a3_o2,  a4_o2,  a5_o2
 
 !
 ! The prefixes "f_" refers to a "field" and "j" to a volumetric rate, and 
@@ -1857,29 +1862,50 @@ write (stdlogunit, generic_bling_nml)
     call g_tracer_add_param('b_2', bling%b_2, -1.03410e-02 )
     call g_tracer_add_param('b_3', bling%b_3, -8.17083e-03)
     call g_tracer_add_param('c_0', bling%c_0, -4.88682e-07)
+    !
     !-----------------------------------------------------------------------
-    !     Schmidt number coefficients
+    !      Schmidt number coefficients
     !-----------------------------------------------------------------------
-    !  Compute the Schmidt number of CO2 in seawater using the 
-    !  formulation presented by Wanninkhof (1992, J. Geophys. Res., 97,
-    !  7373-7382).
-    !-----------------------------------------------------------------------
-    !New Wanninkhof numbers
-    call g_tracer_add_param('a1_co2', bling%a1_co2,  2068.9)
-    call g_tracer_add_param('a2_co2', bling%a2_co2, -118.63)
-    call g_tracer_add_param('a3_co2', bling%a3_co2,  2.9311)
-    call g_tracer_add_param('a4_co2', bling%a4_co2, -0.027)
+    if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+        !  Compute the Schmidt number of CO2 in seawater using the 
+        !  formulation presented by Wanninkhof (1992, J. Geophys. Res., 97,
+        !  7373-7382).
+        call g_tracer_add_param('a1_co2', bling%a1_co2,  2068.9)
+        call g_tracer_add_param('a2_co2', bling%a2_co2, -118.63)
+        call g_tracer_add_param('a3_co2', bling%a3_co2,  2.9311)
+        call g_tracer_add_param('a4_co2', bling%a4_co2, -0.027)
+        call g_tracer_add_param('a5_co2', bling%a5_co2,  0.0)     ! Not used for W92
+        !  Compute the Schmidt number of O2 in seawater using the 
+        !  formulation proposed by Keeling et al. (1998, Global Biogeochem.
+        !  Cycles, 12, 141-163).
+        call g_tracer_add_param('a1_o2', bling%a1_o2, 1929.7)
+        call g_tracer_add_param('a2_o2', bling%a2_o2, -117.46)
+        call g_tracer_add_param('a3_o2', bling%a3_o2, 3.116)
+        call g_tracer_add_param('a4_o2', bling%a4_o2, -0.0306)
+        call g_tracer_add_param('a5_o2', bling%a5_o2, 0.0)       ! Not used for W92
+        if (is_root_pe()) call mpp_error(NOTE,'generic_bling: Using Schmidt number coefficients for W92')
+    else if (trim(as_param_bling) == 'W14') then
+        !  Compute the Schmidt number of CO2 in seawater using the 
+        !  formulation presented by Wanninkhof 
+        !  (2014, Limnol. Oceanogr., 12, 351-362)
+        call g_tracer_add_param('a1_co2', bling%a1_co2,    2116.8)
+        call g_tracer_add_param('a2_co2', bling%a2_co2,   -136.25)
+        call g_tracer_add_param('a3_co2', bling%a3_co2,    4.7353)
+        call g_tracer_add_param('a4_co2', bling%a4_co2, -0.092307)
+        call g_tracer_add_param('a5_co2', bling%a5_co2, 0.0007555)
+        !  Compute the Schmidt number of O2 in seawater using the 
+        !  formulation presented by Wanninkhof 
+        !  (2014, Limnol. Oceanogr., 12, 351-362)
+        call g_tracer_add_param('a1_o2', bling%a1_o2, 1920.4)
+        call g_tracer_add_param('a2_o2', bling%a2_o2, -135.6)
+        call g_tracer_add_param('a3_o2', bling%a3_o2, 5.2122)
+        call g_tracer_add_param('a4_o2', bling%a4_o2, -0.10939)
+        call g_tracer_add_param('a5_o2', bling%a5_o2, 0.00093777)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_bling: Using Schmidt number coefficients for W14')
+    else
+        call mpp_error(FATAL,'generic_BLING: unable to set Schmidt number coefficients for as_param '//trim(as_param_bling))
+    endif
     !---------------------------------------------------------------------
-    !  Compute the Schmidt number of O2 in seawater using the 
-    !  formulation proposed by Keeling et al. (1998, Global Biogeochem.
-    !  Cycles, 12, 141-163).
-    !---------------------------------------------------------------------
-    !New Wanninkhof numbers
-    call g_tracer_add_param('a1_o2', bling%a1_o2, 1929.7)
-    call g_tracer_add_param('a2_o2', bling%a2_o2, -117.46)
-    call g_tracer_add_param('a3_o2', bling%a3_o2, 3.116)
-    call g_tracer_add_param('a4_o2', bling%a4_o2, -0.0306)
-
     call g_tracer_add_param('htotal_scale_lo', bling%htotal_scale_lo, 0.01)
     call g_tracer_add_param('htotal_scale_hi', bling%htotal_scale_hi, 100.0)
 
@@ -2206,7 +2232,17 @@ write (stdlogunit, generic_bling_nml)
   subroutine user_add_tracers(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
     character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+    real :: as_coeff_bling
 
+    if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+      ! Air-sea gas exchange coefficient presented in OCMIP2 protocol.
+      ! Value is 0.337 cm/hr in units of m/s.
+      as_coeff_bling=9.36e-7
+    else
+      ! Value is 0.251 cm/hr in units of m/s
+      as_coeff_bling=6.972e-7
+    endif
+    !-----------------------------------------------------------------------
     !Add here only the parameters that are required at the time of registeration 
     !(to make flux exchanging Ocean tracers known for all PE's) 
     !
@@ -2281,7 +2317,7 @@ write (stdlogunit, generic_bling_nml)
          flux_gas_name  = 'o2_flux',                                &
          flux_gas_type  = 'air_sea_gas_flux_generic',               &
          flux_gas_molwt = WTMO2,                                    &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),               &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /),         &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc' )
 
     !
@@ -2355,21 +2391,21 @@ write (stdlogunit, generic_bling_nml)
       !
       !       DIC (Dissolved inorganic carbon)
       !
-      call g_tracer_add(tracer_list,package_name,    &
-         name       = 'dic',                         &
-         longname   = 'Dissolved Inorganic Carbon',  &
-         units      = 'mol/kg',                      &
-         prog       = .true.,                        &
-         flux_gas       = .true.,                    &
-         flux_gas_name  = 'co2_flux',                &
-         flux_gas_type  = 'air_sea_gas_flux_generic',&
-         flux_gas_molwt = WTMCO2,                    &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),&
+      call g_tracer_add(tracer_list,package_name,                   &
+         name           = 'dic',                                    &
+         longname       = 'Dissolved Inorganic Carbon',             &
+         units          = 'mol/kg',                                 &
+         prog           = .true.,                                   &
+         flux_gas       = .true.,                                   &
+         flux_gas_name  = 'co2_flux',                               &
+         flux_gas_type  = 'air_sea_gas_flux_generic',               &
+         flux_gas_molwt = WTMCO2,                                   &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /),         &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-         flux_runoff    = .true.,                    &
-         flux_param     = (/12.011e-03  /),          &
-         flux_bottom    = .true.,                    &
-         init_value     = 0.001)
+         flux_runoff    = .true.,                                   &
+         flux_param     = (/12.011e-03  /),                         &
+         flux_bottom    = .true.,                                   &
+         init_value     = 0.001                                      )
       !
       !    Cased (CaCO3 concentration in active sediment layer)   
       !
@@ -2393,21 +2429,21 @@ write (stdlogunit, generic_bling_nml)
       !
       !       DIC (Dissolved inorganic carbon)
       !
-      call g_tracer_add(tracer_list,package_name,    &
-         name       = 'dic',                         &
-         longname   = 'Dissolved Inorganic Carbon',  &
-         units      = 'mol/kg',                      &
-         prog       = .true.,                        &
-         flux_gas       = .true.,                    &
-         flux_gas_name  = 'co2_flux',                &
-         flux_gas_type  = 'air_sea_gas_flux_generic',&
-         flux_gas_molwt = WTMCO2,                    &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),&
+      call g_tracer_add(tracer_list,package_name,           &
+         name           = 'dic',                            &
+         longname       = 'Dissolved Inorganic Carbon',     &
+         units          = 'mol/kg',                         &
+         prog           = .true.,                           &
+         flux_gas       = .true.,                           &
+         flux_gas_name  = 'co2_flux',                       &
+         flux_gas_type  = 'air_sea_gas_flux_generic',       &
+         flux_gas_molwt = WTMCO2,                           &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /), &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-         flux_runoff    = .false.,                   &
-         flux_param     = (/12.011e-03  /),          &
-         flux_bottom    = .true.,                    &
-         init_value     = 0.001)
+         flux_runoff    = .false.,                          &
+         flux_param     = (/12.011e-03  /),                 &
+         flux_bottom    = .true.,                           &
+         init_value     = 0.001                              )
       endif                                                    !BURY CACO3>>
     !     
     !Diagnostic Tracers:
@@ -2448,19 +2484,19 @@ write (stdlogunit, generic_bling_nml)
       !   
       !       DIC_sat (Saturation Dissolved inorganic carbon)
       !
-      call g_tracer_add(tracer_list,package_name,    &
-           name       = 'dic_sat',                   &
-           longname   = 'Saturation Dissolved Inorganic Carbon', &
-           units      = 'mol/kg',                    &
-           prog       = .true.,                      &
-           flux_gas       = .true.,                  &
-           flux_gas_name  = 'co2_sat_flux',          &
-           flux_gas_type  = 'air_sea_gas_flux',      &
-           flux_gas_molwt = WTMCO2,                  &
-           flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),&
+      call g_tracer_add(tracer_list,package_name,                     &
+           name           = 'dic_sat',                                &
+           longname       = 'Saturation Dissolved Inorganic Carbon',  &
+           units          = 'mol/kg',                                 &
+           prog           = .true.,                                   &
+           flux_gas       = .true.,                                   &
+           flux_gas_name  = 'co2_sat_flux',                           &
+           flux_gas_type  = 'air_sea_gas_flux',                       &
+           flux_gas_molwt = WTMCO2,                                   &
+           flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /),         &
            flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-           flux_param     = (/12.011e-03  /),        &
-           init_value     = 0.001)
+           flux_param     = (/12.011e-03  /),                         &
+           init_value     = 0.001                                      )
       !
       !Diagnostic tracers
       !
@@ -2478,20 +2514,20 @@ write (stdlogunit, generic_bling_nml)
       if (do_14c) then                                        !<<RADIOCARBON
       !       D14IC (Dissolved inorganic radiocarbon)
       !
-      call g_tracer_add(tracer_list,package_name,       &
-         name       = 'di14c',                          &
-         longname   = 'Dissolved Inorganic Radiocarbon',&
-         units      = 'mol/kg',                         &
-         prog       = .true.,                           &
-         flux_gas       = .true.,                       &
-         flux_gas_name  = 'c14o2_flux',                 &
-         flux_gas_type  = 'air_sea_gas_flux',           &
-         flux_gas_molwt = WTMCO2,                       &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),   &
+      call g_tracer_add(tracer_list,package_name,           &
+         name       = 'di14c',                              &
+         longname   = 'Dissolved Inorganic Radiocarbon',    &
+         units      = 'mol/kg',                             &
+         prog       = .true.,                               &
+         flux_gas       = .true.,                           &
+         flux_gas_name  = 'c14o2_flux',                     &
+         flux_gas_type  = 'air_sea_gas_flux',               &
+         flux_gas_molwt = WTMCO2,                           &
+         flux_gas_param = (/ as_coeff_bling, 9.7561e-06 /), &
          flux_gas_restart_file  = 'ocean_bling_airsea_flux.res.nc', &
-         flux_param     = (/14.e-03  /),                &
-         flux_bottom    = .true.,                       &
-         init_value     = 0.001)
+         flux_param     = (/14.e-03  /),                    &
+         flux_bottom    = .true.,                           &
+         init_value     = 0.001                              )
       !
       !       DO14C (Dissolved organic radiocarbon)
       !
@@ -5012,14 +5048,22 @@ write (stdlogunit, generic_bling_nml)
        !---------------------------------------------------------------------
        !     CO2
        !---------------------------------------------------------------------
-
+  
        !---------------------------------------------------------------------
        !  Compute the Schmidt number of CO2 in seawater using the
        !  formulation presented by Wanninkhof (1992, J. Geophys. Res., 97,
        !  7373-7382).
        !---------------------------------------------------------------------
-       co2_sc_no(i,j) = bling%a1_co2 + ST * (bling%a2_co2 + ST * (bling%a3_co2 + ST * bling%a4_co2)) * &
+       if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+         co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + ST*bling%a4_co2)) * & 
             grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CNT entered W92 for CO2 SNo')
+       else if (trim(as_param_bling) == 'W14') then
+         co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + & 
+                                             ST*(bling%a4_co2 + ST*bling%a5_co2)  ) ) * &
+            grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CNT entered W14 for CO2 SNo')
+       endif
 !       sc_no_term = sqrt(660.0 / (sc_co2 + epsln))
 !
 !       co2_alpha(i,j) = co2_alpha(i,j)* sc_no_term * bling%Rho_0 !nnz: MOM has rho(i,j,1,tau)
@@ -5041,7 +5085,6 @@ write (stdlogunit, generic_bling_nml)
     call g_tracer_set_values(tracer_list,'dic','sc_no',co2_sc_no,isd,jsd)
 
     endif                                                     !CARBON CYCLE>>
-
 
     call g_tracer_get_values(tracer_list,'o2','alpha', o2_alpha ,isd,jsd)
     call g_tracer_get_values(tracer_list,'o2','csurf', o2_csurf ,isd,jsd)
@@ -5095,8 +5138,16 @@ write (stdlogunit, generic_bling_nml)
        ! In 'ocmip2_generic' atmos_ocean_fluxes.F90 coupler formulation,
        ! the schmidt number is carried in explicitly
        !
-       o2_sc_no(i,j)  = bling%a1_o2  + ST * (bling%a2_o2  + ST * (bling%a3_o2  + ST * bling%a4_o2 )) * &
+       if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+         o2_sc_no(i,j)  = bling%a1_o2 + ST * (bling%a2_o2 + ST * (bling%a3_o2 + ST * bling%a4_o2 )) * &
             grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CCNT entered W92 for O2 SNo')
+       else if (trim(as_param_bling) == 'W14') then
+         o2_sc_no(i,j) = bling%a1_o2 + ST*(bling%a2_o2 + ST*(bling%a3_o2 + &
+                                            ST*(bling%a4_o2 + ST*bling%a5_o2)  ) ) * &
+            grid_tmask(i,j,1)
+         ! if (is_root_pe()) call mpp_error(NOTE,'generic_bling: CCNT entered W14 for O2 SNo')
+       endif
        !
        !      renormalize the alpha value for atm o2
        !      data table override for o2_flux_pcair_atm is now set to 0.21
@@ -5127,9 +5178,15 @@ write (stdlogunit, generic_bling_nml)
          !---------------------------------------------------------------------
 
          sal = SSS(i,j) ; ST = SST(i,j)
-         co2_sc_no(i,j) = bling%a1_co2 + ST * (bling%a2_co2 + ST * (bling%a3_co2 + ST * bling%a4_co2)) * &
-            grid_tmask(i,j,1)
-       
+         if ((trim(as_param_bling) == 'W92') .or. (trim(as_param_bling) == 'gfdl_cmip6')) then
+           co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + ST*bling%a4_co2)) * & 
+              grid_tmask(i,j,1)
+         else if (trim(as_param_bling) == 'W14') then
+           co2_sc_no(i,j) = bling%a1_co2 + ST*(bling%a2_co2 + ST*(bling%a3_co2 + & 
+                                               ST*(bling%a4_co2 + ST*bling%a5_co2)  ) ) * &
+              grid_tmask(i,j,1)
+         endif
+
          c14o2_alpha(i,j) = c14o2_alpha(i,j) * bling%Rho_0 
          c14o2_csurf(i,j) = c14o2_csurf(i,j) * bling%Rho_0 
 

--- a/generic_tracers/generic_CFC.F90
+++ b/generic_tracers/generic_CFC.F90
@@ -47,7 +47,6 @@ module generic_CFC
   use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
   use time_manager_mod, only: time_type
   use fm_util_mod,      only: fm_util_start_namelist, fm_util_end_namelist  
-  use fms_mod,          only: open_namelist_file, check_nml_error, close_file
   use fms_mod,          only: stdout, stdlog, mpp_pe, mpp_root_pe
 
   use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -136,7 +136,7 @@ module generic_COBALT
   use constants_mod,     only: WTMCO2, WTMO2,WTMN,rdgas,wtmair
   use data_override_mod, only: data_override
   use fms_mod,           only: write_version_number, FATAL, WARNING, stdout, stdlog,mpp_pe,mpp_root_pe
-  use fms_mod,           only: open_namelist_file, check_nml_error, close_file
+  use fms_mod,           only: check_nml_error
 
   use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list
   use g_tracer_utils, only : g_tracer_add,g_tracer_add_param, g_tracer_set_files
@@ -1539,15 +1539,8 @@ character(len=256), parameter   :: note_header =                                
 !
 stdoutunit=stdout();stdlogunit=stdlog()
 
-#ifdef INTERNAL_FILE_NML
 read (input_nml_file, nml=generic_COBALT_nml, iostat=io_status)
 ierr = check_nml_error(io_status,'generic_COBALT_nml')
-#else
-ioun = open_namelist_file()
-read  (ioun, generic_COBALT_nml,iostat=io_status)
-ierr = check_nml_error(io_status,'generic_COBALT_nml')
-call close_file (ioun)
-#endif
 
 write (stdoutunit,'(/)')
 write (stdoutunit, generic_COBALT_nml)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -9135,13 +9135,13 @@ write (stdlogunit, generic_COBALT_nml)
        rho_dzt_100(i,j) = rho_dzt(i,j,1)
        do n = 1,NUM_PHYTO
           phyto(n)%nlim_bw_100(i,j) = (phyto(n)%no3lim(i,j,1)+phyto(n)%nh4lim(i,j,1))* &
-                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/phyto(n)%f_n_100(i,j)
+                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
           phyto(n)%plim_bw_100(i,j) = phyto(n)%po4lim(i,j,1)* &
-                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/phyto(n)%f_n_100(i,j)
+                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
           phyto(n)%def_fe_bw_100(i,j) = phyto(n)%def_fe(i,j,1)* &
-                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/phyto(n)%f_n_100(i,j)
+                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
           phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim(i,j,1)* &
-                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/phyto(n)%f_n_100(i,j)
+                phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
        enddo   !} n
     enddo; enddo  !} i, j
 
@@ -9647,7 +9647,7 @@ write (stdlogunit, generic_COBALT_nml)
          model_time, rmask = grid_tmask,&
          is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
     if (cobalt%id_kfe_eq_lig .gt. 0)            &
-         used = g_send_data(cobalt%id_kfe_eq_lig, log10(cobalt%kfe_eq_lig),         &
+         used = g_send_data(cobalt%id_kfe_eq_lig, log10(cobalt%kfe_eq_lig+epsln),         &
          model_time, rmask = grid_tmask,&
          is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
     if (cobalt%id_feprime .gt. 0)            &

--- a/generic_tracers/generic_ERGOM.F90
+++ b/generic_tracers/generic_ERGOM.F90
@@ -34,7 +34,7 @@ module generic_ERGOM
 
   use coupler_types_mod,   only: coupler_2d_bc_type
   use field_manager_mod,   only: fm_string_len
-  use fms_mod,             only: write_version_number, open_namelist_file, close_file, check_nml_error  
+  use fms_mod,             only: write_version_number, check_nml_error
   use mpp_mod,             only: mpp_error, NOTE, WARNING, FATAL, stdout, stdlog, input_nml_file
   use mpp_mod,             only: mpp_clock_id, mpp_clock_begin, mpp_clock_end, CLOCK_ROUTINE
   use time_manager_mod,    only: time_type
@@ -856,13 +856,7 @@ contains
     call write_version_number( version, tagname )
 
     ! provide for namelist over-ride of defaults 
-#ifdef INTERNAL_FILE_NML
     read (input_nml_file, nml=ergom_nml, iostat=io_status)
-#else
-    ioun = open_namelist_file()
-    read  (ioun, ergom_nml,iostat=io_status)
-    call close_file (ioun)
-#endif
     ierr = check_nml_error(io_status,'ergom_nml')
 
     write (stdoutunit,'(/)')

--- a/generic_tracers/generic_SF6.F90
+++ b/generic_tracers/generic_SF6.F90
@@ -37,7 +37,6 @@ module generic_SF6
   use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
   use time_manager_mod, only : time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
-  use fms_mod,          only: open_namelist_file, check_nml_error, close_file
   use fms_mod,          only: stdout, stdlog, mpp_pe, mpp_root_pe
 
   use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list

--- a/generic_tracers/generic_abiotic.F90
+++ b/generic_tracers/generic_abiotic.F90
@@ -74,16 +74,6 @@
 !! ab_htotal_valid_min = 3.981E-09
 !! ab_htotal_valid_max = 1.259E-08
 !! #
-!! ab_htotal14c_src_file = INPUT/init_ocean_cobalt.res.nc
-!! ab_htotal14c_src_var_name = htotal
-!! ab_htotal14c_src_var_unit = none
-!! ab_htotal14c_dest_var_name =  ab_htotal14c
-!! ab_htotal14c_dest_var_unit = mol kg-1
-!! ab_htotal14c_src_var_record = 1
-!! ab_htotal14c_src_var_gridspec = NONE
-!! ab_htotal14c_valid_min = 3.981E-09
-!! ab_htotal14c_valid_max = 1.259E-08
-!! #
 !! ## divide by 1e6 to convert from umol/kg to mol/kg
 !! dissicabio_src_file = INPUT/Preind_DIC.nc
 !! dissicabio_src_var_name = Preind_DIC
@@ -155,20 +145,17 @@
 !! #-- Non-CMIP Tracer Fields
 !! "generic_abiotic",   "ab_alk",               "ab_alk",               "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "ab_htotal",            "ab_htotal",            "ocean_abiotic","all",.true.,"none", 2
-!! "generic_abiotic",   "ab_htotal14c",         "ab_htotal14c",         "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "ab_po4",               "ab_po4",               "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "ab_sio4",              "ab_sio4",              "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic",   "jdecay_di14c",         "jdecay_di14c",         "ocean_abiotic","all",.true.,"none", 2
 !! "generic_abiotic_z", "ab_alk",               "ab_alk",               "ocean_abiotic_z","all",.true.,"none",2
 !! "generic_abiotic_z", "ab_htotal",            "ab_htotal",            "ocean_abiotic_z","all",.true.,"none",2
-!! "generic_abiotic_z", "ab_htotal14c",         "ab_htotal14c",         "ocean_abiotic_z","all",.true.,"none",2
 !! "generic_abiotic_z", "ab_po4",               "ab_po4",               "ocean_abiotic_z","all",.true.,"none",2
 !! "generic_abiotic_z", "ab_sio4",              "ab_sio4",              "ocean_abiotic_z","all",.true.,"none",2
 
 !! #-- Non-CMIP Surface Fields
 !! "generic_abiotic",   "sfc_ab_alk",           "sfc_ab_alk",           "ocean_abiotic","all",.true.,"none",2
 !! "generic_abiotic",   "sfc_ab_htotal",        "sfc_ab_htotal",        "ocean_abiotic","all",.true.,"none",2
-!! "generic_abiotic",   "sfc_ab_htotal14c",     "sfc_ab_htotal14c",     "ocean_abiotic","all",.true.,"none",2
 !! "generic_abiotic",   "sfc_ab_po4",           "sfc_ab_po4",           "ocean_abiotic","all",.true.,"none",2
 !! "generic_abiotic",   "sfc_ab_sio4",          "sfc_ab_sio4",          "ocean_abiotic","all",.true.,"none",2
 !! 
@@ -203,6 +190,7 @@ module generic_abiotic
   use g_tracer_utils,    only: g_tracer_set_values,g_tracer_get_pointer,g_tracer_get_common
   use g_tracer_utils,    only: g_tracer_get_values  
   use g_tracer_utils,    only: register_diag_field=>g_register_diag_field
+  use g_tracer_utils,    only: is_root_pe
 
   use FMS_ocmip2_co2calc_mod, only : FMS_ocmip2_co2calc,CO2_dope_vector
 
@@ -218,10 +206,12 @@ module generic_abiotic
   public generic_abiotic_update_from_source
   public generic_abiotic_set_boundary_values
   public generic_abiotic_end
+  public as_param_abiotic
 
-  !The following logical for using this module is overwritten 
-  ! by generic_tracer_nml namelist
+  !The following variables for using this module
+  ! are overwritten by generic_tracer_nml namelist
   logical, save :: do_generic_abiotic = .false.
+  character(len=10), save :: as_param_abiotic   = 'gfdl_cmip6'
 
   real, parameter :: sperd = 24.0 * 3600.0
   real, parameter :: spery = 365.25 * sperd
@@ -253,11 +243,12 @@ namelist /generic_abiotic_nml/ co2_calc
      real :: alkbar               !< Mean global alkalinity (eq/kg)
      real :: sio4_const           !< Silicate (SiO4) concentration (mol/kg)
      real :: po4_const            !< Phosphate (PO4) concentration (mol/kg)
-     real :: a1_co2               !< Wanninkhof Coeff.
-     real :: a2_co2               !< Wanninkhof Coeff.
-     real :: a3_co2               !< Wanninkhof Coeff.
-     real :: a4_co2               !< Wanninkhof Coeff.
-     real :: Rho_0                ! Reference density (kg/m^3)
+     real :: sA_co2               !< Schmidt number Coeff.
+     real :: sB_co2               !< Schmidt number Coeff.
+     real :: sC_co2               !< Schmidt number Coeff.
+     real :: sD_co2               !< Schmidt number Coeff.
+     real :: sE_co2               !< Schmidt number Coeff.
+     real :: Rho_0                !< Reference density (kg/m^3)
 
      ! Restart file names
      character(len=fm_string_len) :: ice_restart_file
@@ -265,7 +256,7 @@ namelist /generic_abiotic_nml/ co2_calc
 
      ! Diagnostic Output IDs
      integer :: id_dissicabioos=-1, id_dissi14cabioos=-1
-     integer :: id_sfc_ab_htotal=-1, id_sfc_ab_htotal14c=-1
+     integer :: id_sfc_ab_htotal=-1
      integer :: id_ab_alk=-1, id_ab_po4=-1, id_ab_sio4=-1
      integer :: id_sfc_ab_alk=-1, id_sfc_ab_po4=-1, id_sfc_ab_sio4=-1
      integer :: id_ab_pco2surf=-1, id_ab_p14co2surf=-1
@@ -317,7 +308,7 @@ namelist /generic_abiotic_nml/ co2_calc
 
   type(CO2_dope_vector)        :: CO2_dope_vec
   type(generic_abiotic_params) :: abiotic
-
+ 
 contains
 
   subroutine generic_abiotic_register(tracer_list)
@@ -368,7 +359,7 @@ contains
 
 !> \brief   Initialize the generic abiotic module
 !!
-!! This subroutine adds the dissicabio, dissi14cabio, ab_htotal, and ab_htotal14c tracers to the list of 
+!! This subroutine adds the dissicabio, dissi14cabio, and ab_htotal tracers to the list of 
 !! generic tracers passed to it via utility subroutine g_tracer_add().  Adds all the parameters 
 !! used by this module via utility subroutine g_tracer_add_param(). Allocates all work arrays used 
 !! in the module. 
@@ -454,10 +445,6 @@ contains
 
     vardesc_temp = vardesc("sfc_ab_htotal","Surface Abiotic Htotal",'h','1','s','mol kg-1','f')
     abiotic%id_sfc_ab_htotal = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("sfc_ab_htotal14c","Surface Abiotic Htotal for 14C",'h','1','s','mol kg-1','f')
-    abiotic%id_sfc_ab_htotal14c = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("ab_pco2surf","Oceanic Abiotic pCO2",'h','1','s','uatm','f')
@@ -578,13 +565,28 @@ contains
     !    g_tracer_add_param(name   , variable   ,  default_value)
     call g_tracer_add_param('sio4_const', abiotic%sio4_const, 7.5e-6) !mol/kg
     call g_tracer_add_param('po4_const',  abiotic%po4_const,  5.0e-7) !mol/kg
+
     !-----------------------------------------------------------------------
-    ! CO2 Solubility coefficients (Wanninkhof numbers)
+    ! CO2 Schmidt number coefficients
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('a1_co2', abiotic%a1_co2, 2068.9)
-    call g_tracer_add_param('a2_co2', abiotic%a2_co2, -118.63)
-    call g_tracer_add_param('a3_co2', abiotic%a3_co2, 2.9311)
-    call g_tracer_add_param('a4_co2', abiotic%a4_co2, -0.027)
+    if ((trim(as_param_abiotic) == 'W92') .or. (trim(as_param_abiotic) == 'gfdl_cmip6')) then
+        call g_tracer_add_param('sA_co2', abiotic%sA_co2, 2068.9)
+        call g_tracer_add_param('sB_co2', abiotic%sB_co2, -118.63)
+        call g_tracer_add_param('sC_co2', abiotic%sC_co2, 2.9311)
+        call g_tracer_add_param('sD_co2', abiotic%sD_co2, -0.027)
+        call g_tracer_add_param('sE_co2', abiotic%sE_co2, 0.0)      ! Not used in W92
+        if (is_root_pe()) call mpp_error(NOTE,'generic_abiotic: Using Schmidt number coefficients for W92')
+    else if (trim(as_param_abiotic) == 'W14') then
+        call g_tracer_add_param('sA_co2', abiotic%sA_co2,  2116.8)
+        call g_tracer_add_param('sB_co2', abiotic%sB_co2, -136.25)
+        call g_tracer_add_param('sC_co2', abiotic%sC_co2,  4.7353)
+        call g_tracer_add_param('sD_co2', abiotic%sD_co2, -0.092307)
+        call g_tracer_add_param('sE_co2', abiotic%sE_co2, -0.0007555)
+        if (is_root_pe()) call mpp_error(NOTE,'generic_abiotic: Using Schmidt number coefficients for W14')
+    else
+        call mpp_error(FATAL,'generic_abiotic: unable to set Schmidt number coefficients for CO2.')
+    endif
+
     !-----------------------------------------------------------------------
     ! H+ Concentration Parameters
     !-----------------------------------------------------------------------
@@ -621,9 +623,19 @@ contains
   subroutine user_add_tracers(tracer_list)
     type(g_tracer_type), pointer :: tracer_list
 
-
     character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+    real :: as_coeff_abiotic
 
+    if ((trim(as_param_abiotic) == 'W92') .or. (trim(as_param_abiotic) == 'gfdl_cmip6')) then
+        ! Air-sea gas exchange coefficient presented in OCMIP2 protocol.
+        ! Value is 0.337 cm/hr in units of m/s.
+        as_coeff_abiotic = 9.36e-7
+    else if (trim(as_param_abiotic) == 'W14') then
+        ! Value is 0.251 cm/hr in units of m/s
+        as_coeff_abiotic = 6.972e-7
+    else
+        call mpp_error(FATAL,'Unable to set wind speed coefficient coefficients for as_param '//trim(as_param_abiotic))
+    endif
 
     call g_tracer_start_param_list(package_name)!nnz: Does this append?
     call g_tracer_add_param('ice_restart_file'   , abiotic%ice_restart_file   , 'ice_ocmip_abiotic.res.nc')
@@ -646,7 +658,6 @@ contains
     !prog_tracers: abiotic
     !diag_tracers: none
     !
-
     call g_tracer_add(tracer_list,package_name,                        &
          name       = 'dissicabio',                                    &
          longname   = 'Abiotic Dissolved Inorganic Carbon Concentration',&
@@ -656,7 +667,7 @@ contains
          flux_gas_name  = 'abco2_flux',                                &
          flux_gas_type  = 'air_sea_gas_flux_generic',                  &
          flux_gas_molwt = WTMCO2,                                      &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),                  &
+         flux_gas_param = (/ as_coeff_abiotic, 9.7561e-06 /),          &
          flux_gas_restart_file  = 'ocmip_abiotic_airsea_flux.res.nc',  &
          flux_runoff= .true.,                                          &
          flux_param = (/12.011e-03  /),                                &
@@ -675,7 +686,7 @@ contains
          flux_gas_name  = 'ab14co2_flux',                              &
          flux_gas_type  = 'air_sea_gas_flux_generic',                  &
          flux_gas_molwt = WTMCO2,                                      &
-         flux_gas_param = (/ 9.36e-07, 9.7561e-06 /),                  &
+         flux_gas_param = (/ as_coeff_abiotic, 9.7561e-06 /),                  &
          flux_gas_restart_file  = 'ocmip_abiotic_airsea_flux.res.nc',  &
          flux_runoff= .true.,                                          &
          flux_param = (/12.011e-03  /),                                &
@@ -691,13 +702,6 @@ contains
          units      = 'mol/kg',                       &
          prog       = .false.,                        &
          init_value = abiotic%htotal_in )
-
-    call g_tracer_add(tracer_list,package_name,               &
-         name       = 'ab_htotal14c',                         &
-         longname   = 'abiotic H+ ion concentration for 14C', &
-         units      = 'mol/kg',                               &
-         prog       = .false.,                                &
-         init_value = abiotic%htotal14c_in )
 
   end subroutine user_add_tracers
 
@@ -734,7 +738,6 @@ contains
          grid_tmask=grid_tmask,grid_mask_coast=mask_coast,grid_kmt=grid_kmt)
 
     call g_tracer_get_values(tracer_list,'ab_htotal',    'field', abiotic%f_htotal       ,isd,jsd,ntau=1)
-    call g_tracer_get_values(tracer_list,'ab_htotal14c', 'field', abiotic%f_htotal14c    ,isd,jsd,ntau=1)
     call g_tracer_get_values(tracer_list,'dissicabio'   ,'field', abiotic%f_dissicabio   ,isd,jsd,ntau=tau)
     call g_tracer_get_values(tracer_list,'dissi14cabio' ,'field', abiotic%f_dissi14cabio ,isd,jsd,ntau=tau)
 
@@ -784,29 +787,22 @@ contains
          co2star=abiotic%abco2_csurf(:,:), alpha=abiotic%abco2_alpha(:,:), &
          pCO2surf=abiotic%abpco2_csurf(:,:))
 
-    call FMS_ocmip2_co2calc(CO2_dope_vec,grid_tmask(:,:,k),&
-         Temp(:,:,k), Salt(:,:,k),                    &
-         abiotic%f_dissi14cabio(:,:,k),                          &
-         abiotic%f_po4(:,:,k),                          &  
-         abiotic%f_sio4(:,:,k),                         &
-         abiotic%f_alk(:,:,k),                          &
-         abiotic%htotal14clo, abiotic%htotal14chi,&
-                                !InOut
-         abiotic%f_htotal14c(:,:,k),                       & 
-                                !OUT
-         co2star=abiotic%ab14co2_csurf(:,:), alpha=abiotic%ab14co2_alpha(:,:), &
-         pCO2surf=abiotic%abp14co2_csurf(:,:))
+    ! Update csurf and alpha based on the atmospheric 14C/12C ratio
 
-    ! Update alpha based on the atmospheric 14C/12C ratio
+    ! The 14C surface concentration (ab14co2_csurf, 14CO2*) is proportional to the 14C surface concentration
+    ! times the ratio of the *ocean* surface carbon concentration (i.e. DI14C/DIC). The 14C solubility (ab14co2_alpha) 
+    ! is proportional to abco2_alpha times the 14C to C ratio of the *atmos* carbon concentration as the 
+    ! ocean carbon solubility mainly depends on temperature and the atmos partial pressure of the gas.
 
     call data_override('OCN', 'delta_14catm', abiotic%delta_14catm(isc:iec,jsc:jec), model_time)
     do j = jsc, jec ; do i = isc, iec  !{
-       abiotic%ab14co2_alpha(i,j) = abiotic%ab14co2_alpha(i,j) * &
+       abiotic%ab14co2_csurf(i,j) = abiotic%abco2_csurf(i,j) * &
+                                   (abiotic%f_dissi14cabio(i,j,1)/(abiotic%f_dissicabio(i,j,1) + epsln))
+       abiotic%ab14co2_alpha(i,j) = abiotic%abco2_alpha(i,j) * &
                                     (1.0 + abiotic%delta_14catm(i,j) * 1.0e-03)
     enddo; enddo ; !} i, j
 
     call g_tracer_set_values(tracer_list,'ab_htotal',   'field',abiotic%f_htotal   ,isd,jsd,ntau=1)
-    call g_tracer_set_values(tracer_list,'ab_htotal14c','field',abiotic%f_htotal14c,isd,jsd,ntau=1)
 
     call g_tracer_set_values(tracer_list,'dissicabio','alpha',abiotic%abco2_alpha    ,isd,jsd)
     call g_tracer_set_values(tracer_list,'dissicabio','csurf',abiotic%abco2_csurf    ,isd,jsd)
@@ -816,7 +812,6 @@ contains
     call g_tracer_get_pointer(tracer_list,'dissicabio',  'field',abiotic%p_dissicabio)
     call g_tracer_get_pointer(tracer_list,'dissi14cabio','field',abiotic%p_dissi14cabio)
     call g_tracer_get_pointer(tracer_list,'ab_htotal','field',abiotic%p_htotal)
-    call g_tracer_get_pointer(tracer_list,'ab_htotal14c','field',abiotic%p_htotal14c)
 
     call g_tracer_get_pointer(tracer_list,'dissicabio','stf_gas',abiotic%stf_gas_dissicabio)
     call g_tracer_get_pointer(tracer_list,'dissi14cabio','stf_gas',abiotic%stf_gas_dissi14cabio)
@@ -892,11 +887,6 @@ contains
 
     if (abiotic%id_sfc_ab_htotal .gt. 0)  &
        used = g_send_data(abiotic%id_sfc_ab_htotal, abiotic%f_htotal(:,:,1),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-
-    if (abiotic%id_sfc_ab_htotal14c .gt. 0)  &
-       used = g_send_data(abiotic%id_sfc_ab_htotal14c, abiotic%f_htotal14c(:,:,1),         &
        model_time, rmask = grid_tmask(:,:,1),&
        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
@@ -982,7 +972,6 @@ contains
        call g_tracer_get_pointer(tracer_list,'dissi14cabio', 'field', dissi14cabio_field)
 
        call g_tracer_get_values(tracer_list, 'ab_htotal', 'field', htotal_field,isd,jsd,ntau=1)
-       call g_tracer_get_values(tracer_list, 'ab_htotal14c', 'field', htotal14c_field,isd,jsd,ntau=1)
 
        do j = jsc, jec ; do i = isc, iec  !{
           abiotic%htotallo(i,j) = abiotic%htotal_scale_lo * htotal_field(i,j,1)
@@ -1022,31 +1011,21 @@ contains
             co2star=abco2_csurf(:,:), alpha=abco2_alpha(:,:),  &
             pCO2surf=abiotic%abpco2_csurf(:,:))
 
+       ! Update csurf and alpha based on the atmospheric 14C/12C ratio
 
-       call FMS_ocmip2_co2calc(CO2_dope_vec,grid_tmask(:,:,1), &
-            SST(:,:), SSS(:,:),                                &
-            dissi14cabio_field(:,:,1,tau),                     &
-            abiotic%f_po4(:,:,1),                              &  
-            abiotic%f_sio4(:,:,1),                             &
-            abiotic%f_alk(:,:,1),                              &
-            abiotic%htotal14clo, abiotic%htotal14chi,          &
-                                !InOut
-            htotal14c_field(:,:,1),                            &
-                                !Optional In
-            co2_calc=trim(co2_calc),                           & 
-            zt=abiotic%zt(:,:,1),                               & 
-                                !OUT
-            co2star=ab14co2_csurf(:,:), alpha=ab14co2_alpha(:,:),&
-            pCO2surf=abiotic%abp14co2_csurf(:,:))
+       ! The 14C surface concentration (ab14co2_csurf, 14CO2*) is proportional to the 14C surface concentration
+       ! times the ratio of the *ocean* surface carbon concentration (i.e. DI14C/DIC). The 14C solubility (ab14co2_alpha) 
+       ! is proportional to abco2_alpha times the 14C to C ratio of the *atmos* carbon concentration as the 
+       ! ocean carbon solubility mainly depends on temperature and the atmos partial pressure of the gas.
 
-    ! Update alpha based on the atmospheric 14C/12C ratio
-    call data_override('OCN', 'delta_14catm', delta_14catm(isc:iec,jsc:jec), model_time)
-    do j = jsc, jec ; do i = isc, iec  !{
-       ab14co2_alpha(i,j) = ab14co2_alpha(i,j) * (1.0 + delta_14catm(i,j) * 1.0e-03)
-    enddo; enddo ; !} i, j
+       call data_override('OCN', 'delta_14catm', delta_14catm(isc:iec,jsc:jec), model_time)
+       do j = jsc, jec ; do i = isc, iec  !{
+          ab14co2_csurf(i,j) = abco2_csurf(i,j) * &
+                              (dissi14cabio_field(i,j,1,tau)/(dissicabio_field(i,j,1,tau) + epsln))
+          ab14co2_alpha(i,j) = abco2_alpha(i,j) * (1.0 + delta_14catm(i,j) * 1.0e-03)
+       enddo; enddo ; !} i, j
 
        call g_tracer_set_values(tracer_list,'ab_htotal' ,'field',htotal_field,isd,jsd,ntau=1)
-       call g_tracer_set_values(tracer_list,'ab_htotal14c','field',htotal14c_field,isd,jsd,ntau=1)
        call g_tracer_set_values(tracer_list,'dissicabio','alpha',abco2_alpha    ,isd,jsd)
        call g_tracer_set_values(tracer_list,'dissicabio','csurf',abco2_csurf    ,isd,jsd)
        call g_tracer_set_values(tracer_list,'dissi14cabio','alpha',ab14co2_alpha    ,isd,jsd)
@@ -1084,11 +1063,23 @@ contains
        !   NOTE: FOR NOW, D14C fixed at 0 permil!! Need to fix this later.
        !---------------------------------------------------------------------
 
-       abco2_sc_no(i,j) = abiotic%a1_co2 + ST * (abiotic%a2_co2 + ST * (abiotic%a3_co2 + ST * abiotic%a4_co2)) * &
-            grid_tmask(i,j,1)
+       if ((trim(as_param_abiotic) == 'W92') .or. (trim(as_param_abiotic) == 'gfdl_cmip6')) then
+           abco2_sc_no(i,j)  =  abiotic%sA_co2 + ST * (abiotic%sB_co2 + ST * (abiotic%sC_co2 + ST * abiotic%sD_co2)) * &
+                                grid_tmask(i,j,1)
 
-       ab14co2_sc_no(i,j) = abiotic%a1_co2 + ST * (abiotic%a2_co2 + ST * (abiotic%a3_co2 + ST * abiotic%a4_co2)) * &
-            grid_tmask(i,j,1)
+           ab14co2_sc_no(i,j) = abiotic%sA_co2 + ST * (abiotic%sB_co2 + ST * (abiotic%sC_co2 + ST * abiotic%sD_co2)) * &
+                                grid_tmask(i,j,1)
+
+       else if (trim(as_param_abiotic) == 'W14') then
+           abco2_sc_no(i,j) = abiotic%sA_co2 + ST*(abiotic%sB_co2 + ST*(abiotic%sC_co2 + & 
+                                               ST*(abiotic%sD_co2 + ST*abiotic%sE_co2))) * &
+                                               grid_tmask(i,j,1)
+
+           ab14co2_sc_no(i,j) = abiotic%sA_co2 + ST*(abiotic%sB_co2 + ST*(abiotic%sC_co2 + & 
+                                               ST*(abiotic%sD_co2 + ST*abiotic%sE_co2))) * &
+                                               grid_tmask(i,j,1)
+
+       endif
 
        ! sc_no_term = sqrt(660.0 / (sc_co2 + epsln))
        !

--- a/generic_tracers/generic_abiotic.F90
+++ b/generic_tracers/generic_abiotic.F90
@@ -180,7 +180,7 @@ module generic_abiotic
   use data_override_mod, only: data_override
   use field_manager_mod, only: fm_string_len
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist
-  use fms_mod,           only: open_namelist_file, check_nml_error, close_file
+  use fms_mod,           only: check_nml_error
   use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum
   use time_manager_mod,  only: time_type
 
@@ -329,15 +329,8 @@ contains
 
     stdoutunit=stdout();stdlogunit=stdlog()
 
-#ifdef INTERNAL_FILE_NML
     read (input_nml_file, nml=generic_abiotic_nml, iostat=io_status)
     ierr = check_nml_error(io_status,'generic_abiotic_nml')
-#else
-    ioun = open_namelist_file()
-    read  (ioun, generic_abiotic_nml,iostat=io_status)
-    ierr = check_nml_error(io_status,'generic_abiotic_nml')
-    call close_file (ioun)
-#endif
     
     write (stdoutunit,'(/)')
     write (stdoutunit, generic_abiotic_nml)

--- a/generic_tracers/generic_blres.F90
+++ b/generic_tracers/generic_blres.F90
@@ -23,7 +23,7 @@ module generic_blres
   use field_manager_mod, only: fm_string_len
   !use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
   use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum
-  use fms_mod,           only: write_version_number, open_namelist_file, check_nml_error, close_file
+  use fms_mod,           only: write_version_number, check_nml_error
   use time_manager_mod, only : time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
 
@@ -92,15 +92,8 @@ integer                                                 :: stdoutunit,stdlogunit
 !
 stdoutunit=stdout();stdlogunit=stdlog()
 
-#ifdef INTERNAL_FILE_NML
 read (input_nml_file, nml=generic_blres_nml, iostat=io_status)
 ierr = check_nml_error(io_status,'generic_blres_nml')
-#else
-ioun = open_namelist_file()
-read  (ioun, generic_bling_nml,iostat=io_status)
-ierr = check_nml_error(io_status,'generic_blres_nml')
-call close_file (ioun)
-#endif
 
 write (stdoutunit,'(/)')
 write (stdoutunit, generic_blres_nml)

--- a/generic_tracers/generic_blres.F90
+++ b/generic_tracers/generic_blres.F90
@@ -1,0 +1,395 @@
+!----------------------------------------------------------------
+! <CONTACT EMAIL="Niki.Zadeh@noaa.gov"> Niki Zadeh 
+! </CONTACT>
+! 
+! <REVIEWER EMAIL="William.Cooke@noaa.gov"> William Cooke
+! </REVIEWER>
+!<OVERVIEW>
+!</OVERVIEW>
+!
+!<DESCRIPTION>
+!       Implementation of routines to solve the amount of time that a water parcel 
+!       at any give location has last resided in the mixed layer
+!</DESCRIPTION>
+!
+! </DEVELOPER_NOTES>
+! </INFO>
+!
+!----------------------------------------------------------------
+
+module generic_blres
+
+  use coupler_types_mod, only: coupler_2d_bc_type
+  use field_manager_mod, only: fm_string_len
+  !use mpp_mod, only : mpp_error, NOTE, WARNING, FATAL, stdout
+  use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum
+  use fms_mod,           only: write_version_number, open_namelist_file, check_nml_error, close_file
+  use time_manager_mod, only : time_type
+  use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  
+
+  use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list
+  use g_tracer_utils, only : g_tracer_add,g_tracer_add_param, g_tracer_set_files
+  use g_tracer_utils, only : g_tracer_set_values,g_tracer_get_pointer,g_tracer_get_common
+  use g_tracer_utils, only : g_tracer_coupler_set,g_tracer_coupler_get
+  use g_tracer_utils, only : g_tracer_send_diag, g_tracer_get_values  
+
+
+  implicit none ; private
+
+  character(len=fm_string_len), parameter :: mod_name       = 'generic_blres'
+  character(len=fm_string_len), parameter :: package_name   = 'generic_blres'
+
+  public do_generic_blres
+  public generic_blres_register
+  public generic_blres_init
+  public generic_blres_update_from_coupler
+  public generic_blres_update_from_source
+  public generic_blres_set_boundary_values
+  public generic_blres_end
+
+  !The following logical for using this module is overwritten 
+  ! by generic_tracer_nml namelist
+  logical, save :: do_generic_blres = .false.
+
+  real, parameter :: epsln=1.0e-30
+
+  real :: reset_time=1.0
+
+  namelist /generic_blres_nml/ reset_time
+  !
+  !This type contains all the parameters and arrays used in this module.
+  !
+  !Note that there is no programatic reason for treating
+  !the following as a type. These are the parameters used only in this module. 
+  !It suffices for varables to be a declared at the top of the module. 
+  !nnz: Find out about the timing overhead for using type%x rather than x
+
+  type generic_blres_params
+      real :: Rho_0
+     character(len=fm_string_len) :: ice_restart_file
+     character(len=fm_string_len) :: ocean_restart_file,IC_file
+  end type generic_blres_params
+
+
+  type(generic_blres_params) :: param
+
+contains
+
+  subroutine generic_blres_register(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+
+integer                                                 :: ioun
+integer                                                 :: ierr
+integer                                                 :: io_status
+character(len=fm_string_len)                            :: name
+integer                                                 :: stdoutunit,stdlogunit
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_register'
+
+! provide for namelist over-ride
+! This needs to go before the add_tracers in order to allow the namelist 
+! settings to switch tracers on and off.
+!
+stdoutunit=stdout();stdlogunit=stdlog()
+
+#ifdef INTERNAL_FILE_NML
+read (input_nml_file, nml=generic_blres_nml, iostat=io_status)
+ierr = check_nml_error(io_status,'generic_blres_nml')
+#else
+ioun = open_namelist_file()
+read  (ioun, generic_bling_nml,iostat=io_status)
+ierr = check_nml_error(io_status,'generic_blres_nml')
+call close_file (ioun)
+#endif
+
+write (stdoutunit,'(/)')
+write (stdoutunit, generic_blres_nml)
+write (stdlogunit, generic_blres_nml)
+
+    !Specify all prognostic and diagnostic tracers of this modules.
+    call user_add_tracers(tracer_list)
+    
+    
+  end subroutine generic_blres_register
+
+  ! <SUBROUTINE NAME="generic_blres_init">
+  !  <OVERVIEW>
+  !   Initialize the generic mixed layer residence tracer
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   This subroutine: 
+  !       Adds all the residence tracers to the list of generic Tracers passed to it via utility subroutine g_tracer_add().
+  !       Adds all the parameters used by this module via utility subroutine g_tracer_add_param().
+  !       Allocates all work arrays used in the module. 
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_blres_init(tracer_list)
+  !  </TEMPLATE>
+  !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
+  !   Pointer to the head of generic tracer list.
+  !  </IN>
+  ! </SUBROUTINE>
+
+  subroutine generic_blres_init(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_init'
+
+    !Specify and initialize all parameters used by this package
+    call user_add_params
+
+    !Allocate and initiate all the private work arrays used by this module.
+    !call user_allocate_arrays 
+
+  end subroutine generic_blres_init
+
+  subroutine user_allocate_arrays
+
+    ! Nothing to do for mixed layer tracer
+    ! call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau) 
+
+  end subroutine user_allocate_arrays
+
+  subroutine user_deallocate_arrays
+  !   This is an internal sub, not a public interface.
+  !   Deallocate all the work arrays allocated by user_allocate_arrays.
+  !
+  end subroutine user_deallocate_arrays
+  !
+  !   This is an internal sub, not a public interface.
+  !   Add all the parameters to be used in this module. 
+  !
+  subroutine user_add_params
+
+    !Specify all parameters used in this modules.
+    !==============================================================
+    !User adds one call for each parameter below!
+    !User also adds the definition of each parameter in generic_blres_params type
+    !==============================================================    
+
+    !=============
+    !Block Starts: g_tracer_add_param
+    !=============
+    !Add the known experimental parameters used for calculations
+    !in this module.
+    !All the g_tracer_add_param calls must happen between 
+    !g_tracer_start_param_list and g_tracer_end_param_list  calls.
+    !This implementation enables runtime overwrite via field_table.
+
+    call g_tracer_start_param_list(package_name)
+    !  Rho_0 is used in the Boussinesq
+    !  approximation to calculations of pressure and
+    !  pressure gradients, in units of kg m-3.
+    call g_tracer_add_param('RHO_0', param%Rho_0, 1035.0)
+
+    call g_tracer_end_param_list(package_name)
+    !===========
+    !Block Ends: g_tracer_add_param
+    !===========
+
+  end subroutine user_add_params
+
+  !
+  !   This is an internal sub, not a public interface.
+  !   Add all the tracers to be used in this module. 
+  !
+  subroutine user_add_tracers(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+
+    character(len=fm_string_len), parameter :: sub_name = 'user_add_tracers'
+
+    call g_tracer_start_param_list(package_name)!nnz: Does this append?
+    call g_tracer_add_param('ice_restart_file'   , param%ice_restart_file   , 'ice_ocmip_blres.res.nc')
+    call g_tracer_add_param('ocean_restart_file' , param%ocean_restart_file , 'ocmip_blres.res.nc' )
+    call g_tracer_add_param('IC_file'       , param%IC_file       , '')
+    call g_tracer_end_param_list(package_name)
+
+    ! Set Restart files
+    call g_tracer_set_files(ice_restart_file=param%ice_restart_file, ocean_restart_file=param%ocean_restart_file )
+
+    !=====================================================
+    !Specify all prognostic tracers of this modules.
+    !=====================================================
+    !User adds one call for each prognostic tracer below!
+    !User should specify if fluxes must be extracted from boundary 
+    !by passing one or more of the following methods as .true.  
+    !and provide the corresponding parameters array
+    !methods: flux_gas,flux_runoff,flux_wetdep,flux_drydep  
+    !
+    !prog_tracers: blres
+    !diag_tracers: none
+    !
+    !age
+    call g_tracer_add(tracer_list,package_name,               &
+         name          = 'blres',                             &
+         longname      = 'residence time inside mixed layer', &
+         units         = 'years',                             &
+         init_value    = 0.0,                                 &
+         prog          = .true.)
+
+    call g_tracer_add(tracer_list,package_name,                &
+         name          = 'blres_inv',                          &
+         longname      = 'residence time outside mixed layer', &
+         units         = 'years',                              &
+         init_value    = 0.0,                                  &
+         prog          = .true.)
+
+
+  end subroutine user_add_tracers
+
+  ! <SUBROUTINE NAME="generic_blres_update_from_coupler">
+  !  <OVERVIEW>
+  !   Modify the values obtained from the coupler if necessary.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Currently an empty stub for ages.
+  !   Some tracer fields need to be modified after values are obtained from the coupler.
+  !   This subroutine is the place for specific tracer manipulations.
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_blres_update_from_coupler(tracer_list) 
+  !  </TEMPLATE>
+  !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
+  !   Pointer to the head of generic tracer list.
+  !  </IN>
+  ! </SUBROUTINE>
+  subroutine generic_blres_update_from_coupler(tracer_list)
+    type(g_tracer_type), pointer :: tracer_list
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_update_from_coupler'
+    !
+    !Nothing specific to be done for mixed layer residence tracers
+    !
+    return
+  end subroutine generic_blres_update_from_coupler
+
+  ! <SUBROUTINE NAME="generic_blres_update_from_source">
+  !  <OVERVIEW>
+  !   Update tracer concentration fields due to the source/sink contributions.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Sets age to zero in uppermost level and increments it by the time step elsewhere
+  !  </DESCRIPTION>
+  ! </SUBROUTINE>
+  subroutine generic_blres_update_from_source( tracer_list,tau,dt,       &
+                                               hblt_depth,dzt,ilb,jlb  )
+
+    type(g_tracer_type),            pointer    :: tracer_list
+    integer,                        intent(in) :: tau, ilb, jlb
+    real,                           intent(in) :: dt
+    real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth
+    real, dimension(ilb:,jlb:,:),   intent(in) :: dzt
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_update_from_source'
+    integer                                 :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,i,j,k
+    real, parameter                         :: secs_in_year_r = 1.0 / (86400.0 * 365.25)
+    real, dimension(:,:,:)  , pointer       :: grid_tmask
+    real, dimension(:,:,:,:), pointer       :: p_blres_field, p_blres_inv_field
+
+    real, dimension(:,:,:), allocatable :: zt
+
+    call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,grid_tmask=grid_tmask)
+
+    allocate( zt(isd:ied,jsd:jed,nk) ); zt=0.0
+
+    call g_tracer_get_pointer(tracer_list, 'blres'    , 'field', p_blres_field    )
+    call g_tracer_get_pointer(tracer_list, 'blres_inv', 'field', p_blres_inv_field)
+
+    ! Compute depth of the bottom of the cell
+    zt = 0.0
+    do j = jsc, jec ; do i = isc, iec   !{
+       zt(i,j,1) = dzt(i,j,1)
+    enddo; enddo !} i,j
+    do k = 2, nk ; do j = jsc, jec ; do i = isc, iec   !{
+       zt(i,j,k) = zt(i,j,k-1) + dzt(i,j,k)
+    enddo; enddo; enddo !} i,j
+
+    do k = 1, nk; do j = jsc, jec ; do i = isc, iec
+
+      if (zt(i,j,k) .le. hblt_depth(i,j) ) then
+        !if ( p_blres_inv_field(i,j,k,tau) .gt. 1 ) then
+        if ( p_blres_inv_field(i,j,k,tau) .gt. reset_time ) then
+          ! Reset tracers
+          p_blres_field    (i,j,k,tau) = 0.0
+          p_blres_inv_field(i,j,k,tau) = 0.0
+        else
+          p_blres_field(i,j,k,tau) = p_blres_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
+        endif
+      else
+        p_blres_inv_field(i,j,k,tau) = p_blres_inv_field(i,j,k,tau) + dt*secs_in_year_r*grid_tmask(i,j,k)
+      endif
+
+    enddo; enddo; enddo !} i,j,k
+
+    deallocate (zt)
+
+    return
+  end subroutine generic_blres_update_from_source
+
+  ! <SUBROUTINE NAME="generic_blres_set_boundary_values">
+  !  <OVERVIEW>
+  !   Calculate and set coupler values at the surface / bottom
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_blres_set_boundary_values(tracer_list,SST,SSS,rho,ilb,jlb,tau)
+  !  </TEMPLATE>
+  !  <IN NAME="tracer_list" TYPE="type(g_tracer_type), pointer">
+  !   Pointer to the head of generic tracer list.
+  !  </IN>
+  !  <IN NAME="ilb,jlb" TYPE="integer">
+  !   Lower bounds of x and y extents of input arrays on data domain
+  !  </IN>
+  !  <IN NAME="SST" TYPE="real, dimension(ilb:,jlb:)">
+  !   Sea Surface Temperature   
+  !  </IN>
+  !  <IN NAME="SSS" TYPE="real, dimension(ilb:,jlb:)">
+  !   Sea Surface Salinity
+  !  </IN>
+  !  <IN NAME="rho" TYPE="real, dimension(ilb:,jlb:,:,:)">
+  !   Ocean density
+  !  </IN>
+  !  <IN NAME="tau" TYPE="integer">
+  !   Time step index of %field
+  !  </IN>
+  ! </SUBROUTINE>
+
+  !User must provide the calculations for these boundary values.
+  subroutine generic_blres_set_boundary_values(tracer_list,ST,SSS,rho,ilb,jlb,taum1)
+    type(g_tracer_type),          pointer    :: tracer_list
+    real, dimension(ilb:,jlb:),     intent(in) :: ST, SSS 
+    real, dimension(ilb:,jlb:,:,:), intent(in) :: rho
+    integer,                        intent(in) :: ilb,jlb,taum1
+
+    integer :: isc,iec, jsc,jec,isd,ied,jsd,jed,nk,ntau , i, j
+    real    :: conv_fac,sal,ta,SST,alpha,sc
+    real, dimension(:,:,:)  ,pointer  :: grid_tmask
+    real, dimension(:,:,:,:), pointer :: g_blres_field
+    real, dimension(:,:), ALLOCATABLE :: g_blres_alpha,g_blres_csurf
+    real, dimension(:,:), ALLOCATABLE :: sc_no
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_set_boundary_values'
+
+    return
+  end subroutine generic_blres_set_boundary_values
+
+  ! <SUBROUTINE NAME="generic_blres_end">
+  !  <OVERVIEW>
+  !   End the module.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Deallocate all work arrays
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_blres_end
+  !  </TEMPLATE>
+  ! </SUBROUTINE>
+
+  subroutine generic_blres_end
+    character(len=fm_string_len), parameter :: sub_name = 'generic_blres_end'
+    !call user_deallocate_arrays
+
+  end subroutine generic_blres_end
+
+end module generic_blres

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -33,7 +33,7 @@
 
 module generic_tracer
 
-  use fms_mod,           only: open_namelist_file, close_file, check_nml_error  
+  use fms_mod,           only: check_nml_error
   use field_manager_mod, only: fm_string_len
   use mpp_mod, only : input_nml_file, mpp_error, NOTE, WARNING, FATAL, stdout, stdlog
   use time_manager_mod, only : time_type
@@ -159,15 +159,8 @@ contains
 
     stdoutunit=stdout();stdlogunit=stdlog()
     ! provide for namelist over-ride of defaults 
-#ifdef INTERNAL_FILE_NML
-read (input_nml_file, nml=generic_tracer_nml, iostat=io_status)
-ierr = check_nml_error(io_status,'generic_tracer_nml')
-#else
-    ioun = open_namelist_file()
-    read  (ioun, generic_tracer_nml,iostat=io_status)
+    read (input_nml_file, nml=generic_tracer_nml, iostat=io_status)
     ierr = check_nml_error(io_status,'generic_tracer_nml')
-    call close_file (ioun)
-#endif
 
     write (stdoutunit,'(/)')
     write (stdoutunit, generic_tracer_nml)

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -50,11 +50,16 @@ module generic_tracer
 
   use generic_abiotic, only : generic_abiotic_register, generic_abiotic_register_diag
   use generic_abiotic, only : generic_abiotic_init, generic_abiotic_update_from_source
-  use generic_abiotic, only : generic_abiotic_set_boundary_values, generic_abiotic_end, do_generic_abiotic
+  use generic_abiotic, only : generic_abiotic_set_boundary_values, generic_abiotic_end, do_generic_abiotic 
+  use generic_abiotic, only : as_param_abiotic
 
   use generic_age,    only : generic_age_register
   use generic_age,    only : generic_age_init, generic_age_update_from_source,generic_age_update_from_coupler
   use generic_age,    only : generic_age_set_boundary_values, generic_age_end, do_generic_age
+
+  use generic_blres, only : generic_blres_register
+  use generic_blres, only : generic_blres_init, generic_blres_update_from_source,generic_blres_update_from_coupler
+  use generic_blres, only : generic_blres_set_boundary_values, generic_blres_end, do_generic_blres
 
   use generic_argon,    only : generic_argon_register
   use generic_argon,    only : generic_argon_init, generic_argon_update_from_source,generic_argon_update_from_coupler
@@ -64,11 +69,13 @@ module generic_tracer
   use generic_CFC,    only : generic_CFC_init, generic_CFC_update_from_source,generic_CFC_update_from_coupler
   use generic_CFC,    only : generic_CFC_set_boundary_values, generic_CFC_end, do_generic_CFC
   use generic_CFC,    only : generic_CFC_register_diag
+  use generic_CFC, only : as_param_cfc
 
   use generic_SF6,    only : generic_SF6_register
   use generic_SF6,    only : generic_SF6_init, generic_SF6_update_from_source,generic_SF6_update_from_coupler
   use generic_SF6,    only : generic_SF6_set_boundary_values, generic_SF6_end, do_generic_SF6
   use generic_SF6,    only : generic_SF6_register_diag
+  use generic_SF6, only : as_param_sf6
 
   use generic_ERGOM, only : generic_ERGOM_register, generic_ERGOM_register_diag
   use generic_ERGOM, only : generic_ERGOM_init, generic_ERGOM_update_from_source,generic_ERGOM_update_from_coupler
@@ -84,6 +91,7 @@ module generic_tracer
   use generic_BLING,  only : generic_BLING_init, generic_BLING_update_from_source,generic_BLING_register_diag
   use generic_BLING,  only : generic_BLING_update_from_bottom,generic_BLING_update_from_coupler
   use generic_BLING,  only : generic_BLING_set_boundary_values, generic_BLING_end, do_generic_BLING
+  use generic_BLING, only : as_param_bling
 
   use generic_miniBLING_mod,  only : generic_miniBLING_init, generic_miniBLING_register
   use generic_miniBLING_mod,  only : generic_miniBLING_update_from_source,generic_miniBLING_register_diag
@@ -95,6 +103,7 @@ module generic_tracer
   use generic_COBALT,  only : generic_COBALT_init, generic_COBALT_update_from_source,generic_COBALT_register_diag
   use generic_COBALT,  only : generic_COBALT_update_from_bottom,generic_COBALT_update_from_coupler
   use generic_COBALT,  only : generic_COBALT_set_boundary_values, generic_COBALT_end, do_generic_COBALT
+  use generic_COBALT, only : as_param_cobalt
 
   implicit none ; private
 
@@ -129,10 +138,11 @@ module generic_tracer
   logical :: do_generic_tracer = .false.
   logical :: generic_tracer_register_called = .false.
   logical :: force_update_fluxes = .false.
+  character(len=10) :: as_param   = 'gfdl_cmip6'     ! Use default Wanninkhoff/OCMIP2 parameters for air-sea gas transfer
 
   namelist /generic_tracer_nml/ do_generic_tracer, do_generic_abiotic, do_generic_age, do_generic_argon, do_generic_CFC, &
       do_generic_SF6, do_generic_TOPAZ,do_generic_ERGOM, do_generic_BLING, do_generic_miniBLING, do_generic_COBALT, &
-      force_update_fluxes
+      force_update_fluxes, do_generic_blres, as_param
 
 contains
 
@@ -163,6 +173,15 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     write (stdoutunit, generic_tracer_nml)
     write (stdlogunit, generic_tracer_nml)
 
+    ! Use Wanninkhoff 2014 parameters for air-sea gas exchange if as_param='W14' in generic_tracer_nml
+    if (as_param == 'gfdl_cmip6') then
+      if (do_generic_abiotic) as_param_abiotic = as_param
+      if (do_generic_CFC)     as_param_cfc     = as_param
+      if (do_generic_SF6)     as_param_sf6     = as_param
+      if (do_generic_BLING)   as_param_bling   = as_param
+      if (do_generic_COBALT)  as_param_cobalt  = as_param
+    endif
+
     call read_mocsy_namelist()
 
     if(do_generic_abiotic) &
@@ -170,6 +189,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     if(do_generic_age) &
          call generic_age_register(tracer_list)
+
+    if(do_generic_blres) &
+         call generic_blres_register(tracer_list)
 
     if(do_generic_argon) &
          call generic_argon_register(tracer_list)
@@ -244,7 +266,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !Allocate and initialize all registered generic tracers
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
        g_tracer => tracer_list        
        !Go through the list of tracers 
        do  
@@ -264,6 +286,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     if(do_generic_age) &
          call generic_age_init(tracer_list)
+
+    if(do_generic_blres) &
+         call generic_blres_init(tracer_list)
 
     if(do_generic_argon) &
          call generic_argon_init(tracer_list)
@@ -299,7 +324,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !JGJ 2013/05/31  merged COBALT into siena_201303
 
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -361,7 +386,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     call g_tracer_coupler_get(tracer_list,IOB_struc)
 
     !Specific tracers
-    !    if(do_generic_age)    call generic_age_update_from_coupler(tracer_list) !Nothing to do for age
+    !    if(do_generic_blres)  call generic_age_update_from_coupler(tracer_list) !Nothing to do for mixed layer tracer
+
+    !    if(do_generic_age)    call generic_blres_update_from_coupler(tracer_list) !Nothing to do for age
 
     !    if(do_generic_argon)    call generic_argon_update_from_coupler(tracer_list) !Nothing to do for argon
 
@@ -504,8 +531,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_source'
 
+    if(do_generic_age)   call generic_age_update_from_source(tracer_list,tau,dtts)
 
-    if(do_generic_age)  call generic_age_update_from_source(tracer_list,tau,dtts)
+    if(do_generic_blres) call generic_blres_update_from_source(tracer_list,tau,dtts,hblt_depth,dzt,ilb,jlb)
 
     !    if(do_generic_argon)    call generic_argon_update_from_source(tracer_list) !Nothing to do for argon
 
@@ -567,6 +595,8 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_bottom'
 
+    !    if(do_generic_blres)  call generic_blres_update_from_bottom(tracer_list)!Nothing to do for mixed layer tracer 
+
     !    if(do_generic_age)    call generic_age_update_from_bottom(tracer_list)!Nothing to do for age 
 
     !    if(do_generic_argon)    call generic_argon_update_from_bottom(tracer_list)!Nothing to do for argon 
@@ -615,7 +645,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !nnz: Should I loop here or inside the sub g_tracer_vertdiff ?    
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -656,7 +686,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !nnz: Should I loop here or inside the sub g_tracer_vertdiff ?    
     !JGJ 2013/05/31  merged COBALT into siena_201303
     if(do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_TOPAZ .or. do_generic_ERGOM &
-       .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) then
+       .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) then
 
        g_tracer => tracer_list        
        !Go through the list of tracers 
@@ -728,6 +758,9 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     if(do_generic_age) &
          call generic_age_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
 
+    if(do_generic_blres) &
+         call generic_blres_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
+
     if(do_generic_argon) &
          call generic_argon_set_boundary_values(tracer_list,ST,SS,rho,ilb,jlb,tau)
 
@@ -758,7 +791,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     !JGJ 2013/05/31  merged COBALT into siena_201303
     !
     if(do_generic_abiotic .or. do_generic_age .or. do_generic_argon .or. do_generic_CFC .or. do_generic_SF6 .or. do_generic_TOPAZ &
-      .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT) &
+      .or. do_generic_ERGOM .or. do_generic_BLING .or. do_generic_miniBLING .or. do_generic_COBALT .or. do_generic_blres) &
        call g_tracer_coupler_set(tracer_list,IOB_struc)
 
   end subroutine generic_tracer_coupler_set
@@ -795,6 +828,7 @@ ierr = check_nml_error(io_status,'generic_tracer_nml')
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_end'
     if(do_generic_abiotic) call generic_abiotic_end
     if(do_generic_age) call generic_age_end
+    if(do_generic_blres) call generic_blres_end
     if(do_generic_argon) call generic_argon_end
     if(do_generic_CFC) call generic_CFC_end
     if(do_generic_SF6) call generic_SF6_end

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -33,7 +33,7 @@ module g_tracer_utils
 
 #ifdef _USE_MOM6_DIAG
     use MOM_diag_mediator, only : register_diag_field_MOM=>register_diag_field
-    use MOM_diag_mediator, only : post_data_MOM=>post_data, post_data_1d_k
+    use MOM_diag_mediator, only : post_data_MOM=>post_data
     use MOM_diag_mediator, only : g_diag_ctrl=>diag_ctrl
 #else
     use diag_manager_mod, only : register_diag_field_FMS=>register_diag_field
@@ -3885,7 +3885,7 @@ contains
     else
        call g_tracer_get_diagCS(diag_CS_ptr)
     endif
-    call post_data_1d_k(diag_field_id, field, diag_CS_ptr)     
+    call post_data_MOM(diag_field_id, field, diag_CS_ptr)     
     g_send_data_1d = .TRUE.
 #else
     g_send_data_1d = send_data_FMS(diag_field_id, field, time, is_in, mask, rmask, ie_in, weight, err_msg)

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -373,6 +373,7 @@ module g_tracer_utils
   public :: g_register_diag_field
   public :: g_send_data
   public :: fm_string_len
+  public :: is_root_pe
   ! <INTERFACE NAME="g_tracer_add_param">
   !  <OVERVIEW>
   !   Add a new parameter for the generic tracer package
@@ -3950,5 +3951,13 @@ contains
 
   END FUNCTION g_send_data_3d
 
+ !> This returns .true. if the current PE is the root PE.
+function is_root_pe()
+  ! This returns .true. if the current PE is the root PE.
+  logical :: is_root_pe
+  is_root_pe = .false.
+  if (mpp_pe() == mpp_root_pe()) is_root_pe = .true.
+  return
+end function is_root_pe
 
 end module g_tracer_utils


### PR DESCRIPTION
These updates are for deprecated use of #ifdef INTERNAL_FILE_NML which is not needed anymore.