### PR TITLE
Make internal_heat optional so it works when geothermal heating is disable in MOM6

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -6448,7 +6448,12 @@ write (stdlogunit, generic_COBALT_nml)
     real, dimension(:),             intent(in) :: max_wavelength_band
     real, dimension(:,ilb:,jlb:),   intent(in) :: sw_pen_band
     real, dimension(:,ilb:,jlb:,:), intent(in) :: opacity_band
-    real, dimension(ilb:,jlb:),     intent(in) :: internal_heat
+
+    ! internal_heat is optional because it will be a NULL pointer if
+    ! geothermal heating is disabled.
+    ! Later it will be tested if it is present (not NULL).
+    real, dimension(ilb:,jlb:),     intent(in), optional :: internal_heat
+
     real, dimension(ilb:,jlb:),     intent(in) :: frunoff 
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_COBALT_update_from_source'
@@ -7847,7 +7852,13 @@ write (stdlogunit, generic_COBALT_nml)
           cobalt%ffe_sed(i,j) = cobalt%ffe_sed_max * tanh( (cobalt%f_ndet_btf(i,j,1)*cobalt%c_2_n*sperd*1.0e3)/ &
                                 max(cobalt%f_o2(i,j,k)*1.0e6,epsln) )
 
-          cobalt%ffe_geotherm(i,j) = cobalt%ffe_geotherm_ratio*internal_heat(i,j)*4184.0/dt
+          ! Have ffe_geotherm default to zero if geothermal heating is disabled (internal_heat is null pointer)
+          if(present(internal_heat)) then
+              cobalt%ffe_geotherm(i,j) = cobalt%ffe_geotherm_ratio*internal_heat(i,j)*4184.0/dt
+          else
+              cobalt%ffe_geotherm(i,j) = 0.0
+          endif
+
           ! default for icebergs: 40 nanomoles fe dissolved per kg of icemelt
           ! sediments: Raiswell et al., 2008: 0.5 kg sed per m-3 of iceberg; 0.1% mean Fe, 5-10% soluble
           ! ~500 nanomoles Fe per kg-1 icemelt 


### PR DESCRIPTION
As @andrew-c-ross originally [reported here](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/issues/85), COBALT uses the internal (geothermal) heat argument to calculate an iron flux:
https://github.com/NOAA-GFDL/ocean_BGC/blob/011b72482e4c7c09c46e26719b79c5324eb02d69/generic_tracers/generic_COBALT.F90#L7850

However, the `internal_heat` is a null pointer by default in MOM6 and is only allocated when `DO_GEOTHERMAL = True` is set in MOM_input/MOM_override:
https://github.com/NOAA-GFDL/MOM6/blob/2c1a9d32fce72828b7091e6f623c0ec20069e637/src/core/MOM.F90#L2812

We will encounter a segmentation fault in COBALT if the user accidentally sets `DO_GEOTHERMAL = false`. This PR, proposed by @andrew-c-ross, addresses this issue by checking if `internal_heat` is a null pointer (by making it an optional argument in `generic_COBALT_update_from_source` subroutine and checking if it is present) and assuming zero internal heating/iron flux if it is null.