### PR TITLE
Allow virtual flux correction based on ocean salt restoring/correction

### DIFF
--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -116,6 +116,7 @@ module generic_tracer
   public generic_tracer_source
   public generic_tracer_diag
   public generic_tracer_update_from_bottom
+  public generic_tracer_update_from_coupler
   public generic_tracer_coupler_get
   public generic_tracer_coupler_set
   public generic_tracer_coupler_zero
@@ -612,6 +613,52 @@ contains
 
   end subroutine generic_tracer_update_from_bottom
 
+  ! <SUBROUTINE NAME="generic_tracer_update_from_coupler">
+  !  <OVERVIEW>
+  !   Modify the values obtained from the coupler
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !   Calls the corresponding generic_X_update_from_coupler routine for each package X.
+  !  </DESCRIPTION>
+  !  <TEMPLATE>
+  !   call generic_tracer_update_from_coupler(ilb, jlb, salt_flux_added)
+  !  </TEMPLATE>
+  !  <IN NAME="ilb,jlb" TYPE="integer">
+  !   Lower bounds of x and y extents of input arrays on data domain
+  !  </IN>
+  !  <IN NAME="salt_flux_added" TYPE="real, dimension(ilb:,jlb:)">
+  !   Surface salt flux into ocean from restoring or flux adjustment [g/m^2/sec]
+  !  </IN>
+  ! </SUBROUTINE>
+
+  subroutine generic_tracer_update_from_coupler(ilb, jlb, salt_flux_added)
+    integer,                     intent(in) :: ilb, jlb
+    real, dimension(ilb:,jlb:),  intent(in) :: salt_flux_added
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_coupler'
+
+    !Specific tracers
+    !    if(do_generic_blres)  call generic_age_update_from_coupler(tracer_list) !Nothing to do for mixed layer tracer
+
+    !    if(do_generic_age)    call generic_blres_update_from_coupler(tracer_list) !Nothing to do for age
+
+    !    if(do_generic_argon)    call generic_argon_update_from_coupler(tracer_list) !Nothing to do for argon
+
+    !    if(do_generic_CFC)    call generic_CFC_update_from_coupler(tracer_list) !Nothing to do for CFC
+
+    !    if(do_generic_SF6)    call generic_SF6_update_from_coupler(tracer_list) !Nothing to do for SF6
+
+    if(do_generic_TOPAZ)  call generic_TOPAZ_update_from_coupler(tracer_list)
+
+    if(do_generic_BLING)  call generic_BLING_update_from_coupler(tracer_list)
+
+    if(do_generic_miniBLING)  call generic_miniBLING_update_from_coupler(tracer_list)
+
+    if(do_generic_COBALT)  call generic_COBALT_update_from_coupler(tracer_list)
+
+    return
+
+   end subroutine generic_tracer_update_from_coupler
 
   ! <SUBROUTINE NAME="generic_tracer_vertdiff_G">
   !  <OVERVIEW>

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -135,6 +135,7 @@ module g_tracer_utils
   !   logical :: flux_wetdep = .false. !Is there a wet deposition?
   !   logical :: flux_drydep = .false. !Is there a dry deposition?
   !   logical :: flux_bottom = .false. !Is there a flux through bottom?
+  !   logical :: flux_virtual = .false. !Is there a virtual flux to be applid to the surface flux?
   !
   !   ! Flux identifiers to be set by aof_set_coupler_flux()
   !   integer :: flux_gas_ind    = -1  
@@ -256,6 +257,7 @@ module g_tracer_utils
      logical :: flux_wetdep = .false. !Is there a wet deposition?
      logical :: flux_drydep = .false. !Is there a dry deposition?
      logical :: flux_bottom = .false. !Is there a flux through bottom?
+     logical :: flux_virtual = .false. !Is there a virtual flux to be applid to the surface flux?
      logical :: has_btm_reservoir = .false. !Is there a flux bottom reservoir?
      logical :: runoff_added_to_stf = .false. ! Has flux in from runoff been added to stf?
 
@@ -724,6 +726,9 @@ contains
   !  <IN NAME="flux_bottom" TYPE="logical">
   !   .true. if there is bottom flux.
   !  </IN>
+  !  <IN NAME="flux_virtual" TYPE="logical">
+  !   .true. to ensure that stf is allocated so that a surface virtual flux can be applied
+  !  </IN>
   !  <IN NAME="btm_reservoir" TYPE="logical">
   !   .true. if there is bottom reservoir.
   !  </IN>
@@ -757,7 +762,8 @@ contains
   subroutine g_tracer_add(node_ptr, package, name, longname, units,  prog, const_init_value,init_value,&
        flux_gas, flux_gas_name, flux_runoff, flux_wetdep, flux_drydep, flux_gas_molwt, flux_gas_param, &
        flux_param, flux_bottom, btm_reservoir, move_vertical, diff_vertical, sink_rate, flux_gas_restart_file, &
-       flux_gas_type,requires_src_info,standard_name,diag_name,diag_field_units,diag_field_scaling_factor,implementation) 
+       flux_gas_type,requires_src_info,standard_name,diag_name,diag_field_units,diag_field_scaling_factor, &
+       implementation, flux_virtual)
 
     type(g_tracer_type), pointer :: node_ptr 
     character(len=*),   intent(in) :: package,name,longname,units
@@ -770,6 +776,7 @@ contains
     logical,            intent(in), optional :: flux_wetdep
     logical,            intent(in), optional :: flux_drydep
     logical,            intent(in), optional :: flux_bottom
+    logical,            intent(in), optional :: flux_virtual
     logical,            intent(in), optional :: btm_reservoir
     logical,            intent(in), optional :: move_vertical
     logical,            intent(in), optional :: diff_vertical
@@ -918,6 +925,8 @@ contains
 
     if(present(flux_bottom))  g_tracer%flux_bottom = flux_bottom
 
+    if(present(flux_virtual))  g_tracer%flux_virtual = flux_virtual
+
     if(present(btm_reservoir)) g_tracer%has_btm_reservoir = btm_reservoir
 
     if(present(move_vertical)) g_tracer%move_vertical = move_vertical
@@ -1035,7 +1044,8 @@ contains
     endif
     !Surface flux %stf exists if one of the following fluxes were requested:
 
-    if(g_tracer%flux_gas .or. g_tracer%flux_runoff .or. g_tracer%flux_wetdep .or. g_tracer%flux_drydep) then
+    if(g_tracer%flux_gas .or. g_tracer%flux_runoff .or. g_tracer%flux_wetdep .or. g_tracer%flux_drydep &
+          .or. g_tracer%flux_virtual) then
        allocate(g_tracer%stf(isd:ied,jsd:jed)); g_tracer%stf(:,:) = 0.0 
     endif
     
@@ -1536,7 +1546,8 @@ contains
        !runoff contributes to %stf in GOLD but not in MOM, 
        !so it will be added later in the model-dependent driver code (GOLD_generic_tracer.F90)
 
-       if(g_tracer%flux_gas .or. g_tracer%flux_drydep .or. g_tracer%flux_wetdep .or. g_tracer%flux_runoff ) then
+       if(g_tracer%flux_gas .or. g_tracer%flux_drydep .or. g_tracer%flux_wetdep .or. g_tracer%flux_runoff &
+             .or. g_tracer%flux_virtual) then
           call g_tracer_set_values(g_tracer,g_tracer%name,'stf',stf_array,&
                g_tracer_com%isd,g_tracer_com%jsd, weight)
        endif


### PR DESCRIPTION
This PR implements changes that allow `stf` adjustments based on any salt restoring/correction applied by the ocean model. There are two changes in this PR:

- A `generic_tracer::generic_tracer_update_from_coupler` routine has been added. This receives the salt flux restoring/correction applied by the ocean and passes it on to the generic tracer's `update_from_coupler` routine.
- An optional input `flux_virtual` has been added to the `generic_tracer_utils::g_tracer_add` routine. If true, this ensures that the `stf` field is allocated on the tracer being added.

Unfortunately, changes are needed to the calling ocean model in order to utilize the changes in this PR:

- In MOM5, the existing call to `generic_tracer::generic_tracer_coupler_get` is replaced by a call to `generic_tracer::generic_tracer_coupler_accumulate` and then `generic_tracer::generic_tracer_update_from_coupler` is called as part of `ocean_sbc_mod::flux_adjust`. See [here](https://github.com/mom-ocean/MOM5/pull/390) for the changes.
- In MOM6, the salt flux added is accumulated and `generic_tracer::generic_tracer_update_from_coupler` is called in `MOM_generic_tracer::MOM_generic_tracer_column_physics`. See [here](https://github.com/mom-ocean/MOM6/compare/main...dougiesquire:MOM6:gtracer-vstf) for the changes.

Merging this PR but not changing the ocean model will mean no change from current behaviour.

Closes #32