### PR TITLE
remove path length imports from field manager

### DIFF
--- a/generic_tracers/generic_BLING.F90
+++ b/generic_tracers/generic_BLING.F90
@@ -170,7 +170,7 @@
 module generic_BLING
 
   use coupler_types_mod, only: coupler_2d_bc_type
-  use field_manager_mod, only: fm_string_len, fm_path_name_len
+  use field_manager_mod, only: fm_string_len
   use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum
   use fms_mod,           only: write_version_number, check_nml_error
   use time_manager_mod,  only: time_type

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -127,7 +127,7 @@
 module generic_COBALT
 
   use coupler_types_mod, only: coupler_2d_bc_type
-  use field_manager_mod, only: fm_string_len, fm_path_name_len
+  use field_manager_mod, only: fm_string_len
   use mpp_mod,           only: mpp_clock_id, mpp_clock_begin, mpp_clock_end
   use mpp_mod,           only: CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_MODULE
   use mpp_mod,           only: input_nml_file, mpp_error, stdlog, NOTE, WARNING, FATAL, stdout, mpp_chksum

--- a/generic_tracers/generic_TOPAZ.F90
+++ b/generic_tracers/generic_TOPAZ.F90
@@ -78,7 +78,7 @@
 module generic_TOPAZ
 
   use coupler_types_mod, only: coupler_2d_bc_type
-  use field_manager_mod, only: fm_string_len, fm_path_name_len
+  use field_manager_mod, only: fm_string_len
   use mpp_mod,           only: mpp_error, NOTE, WARNING, FATAL, stdout, mpp_chksum
   use time_manager_mod,  only: time_type
   use fm_util_mod,       only: fm_util_start_namelist, fm_util_end_namelist  

--- a/generic_tracers/generic_miniBLING.F90
+++ b/generic_tracers/generic_miniBLING.F90
@@ -88,7 +88,7 @@ module generic_miniBLING_mod
 #include <fms_platform.h>
 
   use coupler_types_mod, only: coupler_2d_bc_type
-  use field_manager_mod, only: fm_string_len, fm_path_name_len, fm_field_name_len
+  use field_manager_mod, only: fm_string_len, fm_field_name_len
   use mpp_mod,           only: mpp_error, NOTE, FATAL
   use mpp_mod,           only: stdout
   use time_manager_mod,  only: time_type

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -26,7 +26,7 @@ module g_tracer_utils
   use mpp_mod,           only: mpp_pe, mpp_root_pe, mpp_sync
   use time_manager_mod, only : time_type
 
-  use field_manager_mod, only: fm_string_len, fm_path_name_len, fm_new_list, fm_change_list, fm_get_value
+  use field_manager_mod, only: fm_string_len, fm_new_list, fm_change_list, fm_get_value
   use field_manager_mod, only: fm_dump_list, fm_loop_over_list
 
   use fms_mod,           only: stdout


### PR DESCRIPTION
Removes path length variables imported from the field manager. I'm not sure why these are imported since I don't see any other usage.

This update is so we can remove the variable from FMS and only use a global path length across all modules:

https://github.com/NOAA-GFDL/FMS/issues/1564